### PR TITLE
ci: standardize backend-tests pnpm setup

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -17,13 +17,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        with:
+          version: 8.15.0
+
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "25.x"
-
-      - name: Install pnpm
-        run: npm install -g pnpm@8.15.0
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Updates backend-tests.yml to use pnpm/action-setup and enable pnpm caching via actions/setup-node, matching the pattern used in other workflows.