### PR TITLE
feat(observability): Phase 10 — Loki, Promtail, Alertmanager, trace↔log correlation

### DIFF
--- a/.github/prompts/plan-nextNodeAppBase.prompt.md
+++ b/.github/prompts/plan-nextNodeAppBase.prompt.md
@@ -9,7 +9,7 @@ This plan is analysis-first. It does not authorize destructive moves. It should 
 ## Current Snapshot
 
 - **Stable and merged**: frontend auth/UI boundary cleanup and lint/CI boundary enforcement are complete.
-- **In progress**: distributed tracing is implemented on `feat/phase-10-jaeger-tracing` and open as PR #51.
+- **Stable and merged**: distributed tracing (`feat/phase-10-jaeger-tracing`, PR #51) is complete.
 - **Next execution target**: finish the remaining Phase 10 observability slice: Loki, Grafana Jaeger-to-Loki rewiring, Alertmanager, and Kiali.
 
 ## Guardrails
@@ -431,18 +431,17 @@ Consequence: lower migration risk and clearer package boundaries.
   - Layered architecture (`useSignIn` → `AuthApplicationService` → `authApi` → `apiClient`) established.
   - `requireCurrentUser()` and `getBddStatusSnapshot()` server gateways in place.
   - `copilot-instructions.md` added with SOLID + boundary rules.
-- ✅ Frontend boundary enforcement landed after PR #50.
-  - Root ESLint config blocks direct `fetch()` in frontend UI-facing files.
-  - `.github/workflows/lint.yml` runs ESLint in CI.
-  - `CONTRIBUTING.md` documents the architecture boundary and allowed transport layers.
-- ✅ `feat/phase-10-jaeger-tracing` is implemented and open as PR #51.
-  - Jaeger Kubernetes manifests, Grafana datasource, backend OpenTelemetry bootstrap, ADR-019, and observability docs are in the PR.
-  - Trace-to-logs rewiring is intentionally deferred until Loki rollout.
+- ✅ `feat/lint-ci-boundary-enforcement` merged to master as PR #57 (May 2026).
+  - `no-restricted-syntax` ESLint rule blocks raw `fetch()` in `components/**`, `app/**/!(route).{ts,tsx}`, and `src/hooks/**`; `app/api/**` excluded entirely via `ignores`.
+  - `.github/workflows/lint.yml` runs `pnpm -w lint` in CI on every push and PR; ESLint JSON report uploaded as artifact on failure.
+  - `CONTRIBUTING.md` documents the frontend layering rule, exact blocked globs, and allowed transport layers.
+- ✅ `feat/phase-10-jaeger-tracing` merged to master as PR #51 (May 2026).
+  - Jaeger Kubernetes manifests, Grafana datasource, backend OpenTelemetry bootstrap, ADR-019, and observability docs delivered.
+  - Trace-to-logs rewiring (`tracesToLogsV2`) intentionally deferred until Loki rollout.
 
 ### Next priority (in order)
 
 1. **Phase 10 observability remainder** — Loki centralized logging, **rewire Grafana Jaeger `tracesToLogsV2` to Loki datasource during Loki rollout**, Alertmanager, Kiali.
-2. **Merge PR #51 (`feat/phase-10-jaeger-tracing`)** — completes the distributed tracing slice of Phase 10.
-3. **E2E personas moderator** (branch: `chore/e2e-personas-moderator`) — adds `moderator` persona + `MODERATOR` role; still on hold.
-4. **Contract package extraction** (Migration Plan step 6) — once the second consumer app (`the-azure-citadel`) is bootstrapped, promote stable DTOs from `lib/contracts/` into `@repo/types` or a successor `@repo/contracts` package.
-5. **Phase 8.5 Feature Management System** — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks. No code exists yet.
+2. **E2E personas moderator** (branch: `chore/e2e-personas-moderator`) — adds `moderator` persona + `MODERATOR` role; still on hold.
+3. **Contract package extraction** (Migration Plan step 6) — once the second consumer app (`the-azure-citadel`) is bootstrapped, promote stable DTOs from `lib/contracts/` into `@repo/types` or a successor `@repo/contracts` package.
+4. **Phase 8.5 Feature Management System** — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks. No code exists yet.

--- a/.github/prompts/plan-nextNodeAppBase.prompt.md
+++ b/.github/prompts/plan-nextNodeAppBase.prompt.md
@@ -10,7 +10,7 @@ This plan is analysis-first. It does not authorize destructive moves. It should 
 
 - **Stable and merged**: frontend auth/UI boundary cleanup and lint/CI boundary enforcement are complete.
 - **Stable and merged**: distributed tracing (`feat/phase-10-jaeger-tracing`, PR #51) is complete.
-- **Next execution target**: finish the remaining Phase 10 observability slice: Loki, Grafana Jaeger-to-Loki rewiring, Alertmanager, and Kiali.
+- **In progress**: Phase 10 observability remainder on `feat/phase-10-loki-alertmanager` — Loki, Promtail, Alertmanager manifests written; Grafana `tracesToLogsV2` wired; ADR-020 authored.
 
 ## Guardrails
 
@@ -441,7 +441,7 @@ Consequence: lower migration risk and clearer package boundaries.
 
 ### Next priority (in order)
 
-1. **Phase 10 observability remainder** — Loki centralized logging, **rewire Grafana Jaeger `tracesToLogsV2` to Loki datasource during Loki rollout**, Alertmanager, Kiali.
+1. **Phase 10 observability remainder** — ✅ Loki + Promtail manifests written, Alertmanager manifests written, Grafana `tracesToLogsV2` wired to Loki, ADR-020 authored. Remaining: Kiali (low priority, deferred until Istio is in use). **Branch: `feat/phase-10-loki-alertmanager`**.
 2. **E2E personas moderator** (branch: `chore/e2e-personas-moderator`) — adds `moderator` persona + `MODERATOR` role; still on hold.
 3. **Contract package extraction** (Migration Plan step 6) — once the second consumer app (`the-azure-citadel`) is bootstrapped, promote stable DTOs from `lib/contracts/` into `@repo/types` or a successor `@repo/contracts` package.
 4. **Phase 8.5 Feature Management System** — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks. No code exists yet.

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ prisma/*.db-journal
 *.kubeconfig
 # Real Kubernetes Secret manifests — use *.example.yaml in git instead
 kubernetes/observability/grafana/grafana-secret.yaml
+kubernetes/observability/alertmanager/alertmanager-secret.yaml
 
 # Temporary files
 tmp/

--- a/apps/backend/src/services/logger.service.ts
+++ b/apps/backend/src/services/logger.service.ts
@@ -1,5 +1,6 @@
 import { inspect } from 'node:util';
 
+import { trace, TraceFlags } from '@opentelemetry/api';
 import { singleton } from 'tsyringe';
 import winston from 'winston';
 
@@ -74,11 +75,30 @@ export class LoggerService {
       return info;
     });
 
+    // Inject the active OpenTelemetry trace and span IDs so that structured
+    // log lines written to Loki can be linked back to Jaeger traces via
+    // Grafana's derivedFields.  Only set when a sampled span is active;
+    // degrades to a no-op when tracing is disabled or not sampled.
+    const injectTraceContext = winston.format((info) => {
+      if (info['traceId'] == null) {
+        const span = trace.getActiveSpan();
+        if (span) {
+          const ctx = span.spanContext();
+          if (ctx.traceFlags & TraceFlags.SAMPLED) {
+            info['traceId'] = ctx.traceId;
+            info['spanId'] = ctx.spanId;
+          }
+        }
+      }
+      return info;
+    });
+
     const logFormat = winston.format.combine(
       winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
       winston.format.errors({ stack: true }),
       winston.format.splat(),
       injectCorrelationIdFromContext(),
+      injectTraceContext(),
       winston.format.json()
     );
 
@@ -86,6 +106,7 @@ export class LoggerService {
       winston.format.colorize(),
       winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
       injectCorrelationIdFromContext(),
+      injectTraceContext(),
       winston.format.printf((info) => {
         const record = info as Record<string, unknown>;
         const {

--- a/apps/backend/src/tests/services/logger.service.test.ts
+++ b/apps/backend/src/tests/services/logger.service.test.ts
@@ -1,5 +1,9 @@
+import { PassThrough } from 'node:stream';
+
+import { trace, TraceFlags } from '@opentelemetry/api';
 import { container } from 'tsyringe';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import winston from 'winston';
 
 import { LoggerService } from '../../services/logger.service';
 
@@ -80,5 +84,77 @@ describe('LoggerService', () => {
       expect(logger).toHaveProperty('warn');
       expect(logger).toHaveProperty('error');
     });
+  });
+});
+
+function captureNextLog(logger: winston.Logger): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    const stream = new PassThrough();
+    const transport = new winston.transports.Stream({ stream });
+    stream.once('data', (chunk: Buffer) => {
+      logger.remove(transport);
+      resolve(JSON.parse(chunk.toString().trim()) as Record<string, unknown>);
+    });
+    logger.add(transport);
+  });
+}
+
+describe('LoggerService — injectTraceContext format step', () => {
+  let loggerService: LoggerService;
+
+  beforeEach(() => {
+    process.env['LOG_LEVEL'] = 'debug';
+    loggerService = container.resolve(LoggerService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('includes traceId and spanId when a sampled span is active', async () => {
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue({
+      spanContext: () => ({
+        traceId: 'a'.repeat(32),
+        spanId: 'b'.repeat(16),
+        traceFlags: TraceFlags.SAMPLED,
+        isRemote: false,
+      }),
+    });
+
+    const capture = captureNextLog(loggerService.getLogger());
+    loggerService.info('sampled span test');
+    const output = await capture;
+
+    expect(output).toHaveProperty('traceId', 'a'.repeat(32));
+    expect(output).toHaveProperty('spanId', 'b'.repeat(16));
+  });
+
+  it('omits traceId and spanId when there is no active span', async () => {
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(undefined);
+
+    const capture = captureNextLog(loggerService.getLogger());
+    loggerService.info('no span test');
+    const output = await capture;
+
+    expect(output).not.toHaveProperty('traceId');
+    expect(output).not.toHaveProperty('spanId');
+  });
+
+  it('omits traceId and spanId when the active span is not sampled', async () => {
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue({
+      spanContext: () => ({
+        traceId: 'a'.repeat(32),
+        spanId: 'b'.repeat(16),
+        traceFlags: 0,
+        isRemote: false,
+      }),
+    });
+
+    const capture = captureNextLog(loggerService.getLogger());
+    loggerService.info('unsampled span test');
+    const output = await capture;
+
+    expect(output).not.toHaveProperty('traceId');
+    expect(output).not.toHaveProperty('spanId');
   });
 });

--- a/docs/adr/020-loki-promtail-alertmanager-observability.md
+++ b/docs/adr/020-loki-promtail-alertmanager-observability.md
@@ -1,0 +1,122 @@
+# ADR 020: Loki + Promtail for Centralized Log Aggregation and Alertmanager for Alert Routing
+
+Status: Accepted
+Date: 2026-05-20
+Authors: apkasten906
+
+## Context
+
+The observability stack now provides:
+
+- **Prometheus** — metrics scraping and alerting rules (ADR-015, ADR-016).
+- **Grafana** — visualization dashboards (ADR-017).
+- **Jaeger** — distributed tracing via OpenTelemetry (ADR-019).
+
+Two gaps remain to complete the Phase 10 observability slice:
+
+1. **Centralized log aggregation**: container logs are currently only accessible via `kubectl logs`, which requires cluster access and does not support cross-service correlation or retention. There is no way to correlate a log line with the trace that produced it.
+2. **Alert routing**: Prometheus already evaluates alerting rules but the `alertmanagers` stanza in `prometheus-config.yaml` was commented out, meaning fired alerts are silently dropped. No notification path exists for on-call engineers.
+
+Completing these two gaps closes the observability triad (metrics, logs, traces) and makes the Grafana `tracesToLogsV2` integration viable.
+
+## Decision
+
+### Log aggregation: Loki + Promtail
+
+Adopt **Grafana Loki** as the log storage and query backend and **Promtail** as the log collection agent.
+
+- Loki stores logs indexed by label set rather than by full-text, keeping storage costs low compared to Elasticsearch-class solutions.
+- Promtail runs as a DaemonSet and tails `/var/log/pods/**/*.log` on every node. It labels log streams with `namespace`, `pod`, `container`, and `app` derived from Kubernetes metadata, enabling label-based correlation with Prometheus metrics.
+- Grafana already ships a first-class Loki datasource plugin; no additional components are required.
+
+### Alert routing: Alertmanager
+
+Adopt **Prometheus Alertmanager** as the alert routing backend.
+
+- Prometheus `alerting` stanza in `prometheus-config.yaml` is activated to forward fired alerts to `alertmanager:9093`.
+- Alertmanager routes alerts by severity label: `critical` → `critical-receiver`, `warning` → `warning-receiver`, default → `null` (silenced).
+- Receivers are configured as webhooks in the `alertmanager-config` ConfigMap. Credentials (webhook URLs) are injected at deploy time from `alertmanager-secret`.
+- Inhibition rules suppress `warning` alerts when a `critical` alert for the same `{alertname, cluster, service}` tuple is already firing.
+
+### Grafana trace-to-logs wiring
+
+With Loki provisioned, the Jaeger datasource in `grafana-config.yaml` is updated with `tracesToLogsV2`:
+
+- Spans link to Loki log lines via `app`, `namespace`, and `pod` labels.
+- A `derivedFields` rule on the Loki datasource extracts `traceId` from structured JSON logs and links directly to the corresponding Jaeger trace.
+
+## Implementation
+
+### New files
+
+| File                                                                     | Purpose                                                                              |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `kubernetes/observability/loki/loki-config.yaml`                         | Loki single-binary ConfigMap (TSDB schema v13, filesystem storage, 31-day retention) |
+| `kubernetes/observability/loki/loki-deployment.yaml`                     | Loki Deployment + ClusterIP Service + 10 Gi PVC                                      |
+| `kubernetes/observability/loki/loki-network-policy.yaml`                 | Least-privilege NetworkPolicy: Promtail push, Grafana query, Prometheus scrape only  |
+| `kubernetes/observability/promtail/promtail-daemonset.yaml`              | ServiceAccount, ClusterRole/Binding, ConfigMap, DaemonSet                            |
+| `kubernetes/observability/promtail/promtail-network-policy.yaml`         | Egress to Loki + Kubernetes API; ingress from Prometheus only                        |
+| `kubernetes/observability/alertmanager/alertmanager-config.yaml`         | Route tree + webhook receivers ConfigMap                                             |
+| `kubernetes/observability/alertmanager/alertmanager-secret.example.yaml` | Webhook URL secret template (do not commit populated values)                         |
+| `kubernetes/observability/alertmanager/alertmanager-deployment.yaml`     | Alertmanager Deployment + ClusterIP Service + 2 Gi PVC                               |
+| `kubernetes/observability/alertmanager/alertmanager-network-policy.yaml` | Ingress from Prometheus only; egress to HTTPS webhooks                               |
+
+### Modified files
+
+| File                                                           | Change                                                                                          |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `kubernetes/observability/grafana/grafana-config.yaml`         | Added Loki datasource; added `tracesToLogsV2` + `derivedFields` to Jaeger datasource            |
+| `kubernetes/observability/grafana/grafana-network-policy.yaml` | Added egress rule for Loki port 3100                                                            |
+| `kubernetes/observability/prometheus-config.yaml`              | Activated `alerting.alertmanagers` stanza; added ports 9080, 9093, 3100 to pod scrape allowlist |
+| `kubernetes/observability/prometheus-network-policy.yaml`      | Added egress rules for Alertmanager (9093), Loki (3100), Promtail (9080) scraping               |
+
+### Key ports
+
+| Component         | Port | Protocol |
+| ----------------- | ---- | -------- |
+| Loki HTTP API     | 3100 | HTTP     |
+| Promtail metrics  | 9080 | HTTP     |
+| Alertmanager HTTP | 9093 | HTTP     |
+
+### Environment: Kubernetes deployment order
+
+```
+1. kubectl apply -f kubernetes/observability/loki/
+2. kubectl apply -f kubernetes/observability/promtail/
+3. kubectl apply -f kubernetes/observability/alertmanager/alertmanager-config.yaml
+4. kubectl apply -f kubernetes/observability/alertmanager/alertmanager-secret.yaml  # populated copy
+5. kubectl apply -f kubernetes/observability/alertmanager/alertmanager-deployment.yaml
+6. kubectl apply -f kubernetes/observability/alertmanager/alertmanager-network-policy.yaml
+7. kubectl apply -f kubernetes/observability/grafana/grafana-config.yaml  # updated datasources
+8. kubectl apply -f kubernetes/observability/grafana/grafana-network-policy.yaml
+9. kubectl apply -f kubernetes/observability/prometheus-config.yaml  # activates alertmanager route
+10. kubectl apply -f kubernetes/observability/prometheus-network-policy.yaml
+11. kubectl rollout restart deployment/grafana deployment/prometheus -n observability
+```
+
+## Rationale
+
+### Loki over Elasticsearch / OpenSearch
+
+Loki indexes only labels, not full log content. This makes ingest and storage dramatically cheaper for a platform template where log volume is unpredictable. LogQL supports full-text search over the log body at query time; indexed labels are sufficient for the correlation use cases (by pod, namespace, app, traceId).
+
+### Promtail over Fluentd / Fluentbit
+
+Promtail is purpose-built for Loki and ships with a Kubernetes service-discovery configuration that mirrors Prometheus's `kubernetes-pods` job. The resulting label set is identical to what Prometheus uses, which is essential for seamless Explore correlation in Grafana. Fluentd/Fluentbit are appropriate when a multi-backend fan-out is needed; that is not a current requirement.
+
+### Single-replica Alertmanager over HA mesh
+
+A two-node mesh adds operational complexity (gossip protocol, PVC replicas) for marginal benefit in a development/staging cluster. The `--cluster.listen-address=` flag disables the mesh. When multi-replica HA is needed, remove the flag and add a headless Service for peer discovery.
+
+### Webhook receivers over integrated Slack/PagerDuty
+
+Receiver type is deployment-specific. Webhooks are the most portable default — they work with any HTTP endpoint including Slack incoming webhooks, PagerDuty Events API v2, and custom notification bridges. The `alertmanager-config.yaml` ConfigMap documents where to substitute receiver-specific stanzas.
+
+## Consequences
+
+- **Positive**: the observability triad is complete; Grafana Explore supports unified metrics + logs + traces correlation from a single query.
+- **Positive**: fired Prometheus alerts now reach an operator inbox instead of being silently dropped.
+- **Positive**: `tracesToLogsV2` in Grafana is now wired, enabling one-click navigation from a Jaeger trace span to the corresponding Loki log stream.
+- **Negative**: two additional PVCs (Loki 10 Gi, Alertmanager 2 Gi) are required in the cluster.
+- **Negative**: Promtail runs as root to read host log files. This is the expected and documented trade-off for log collection via hostPath; the blast radius is contained by a dedicated ServiceAccount with a minimal ClusterRole.
+- **Neutral**: Loki uses in-cluster filesystem storage. Log data is lost if the PVC is deleted. For production, migrate to object storage (GCS/S3) and enable the ruler component for alerting on log patterns.

--- a/docs/adr/020-loki-promtail-alertmanager-observability.md
+++ b/docs/adr/020-loki-promtail-alertmanager-observability.md
@@ -44,6 +44,7 @@ With Loki provisioned, the Jaeger datasource in `grafana-config.yaml` is updated
 
 - Spans link to Loki log lines via `app`, `namespace`, and `pod` labels.
 - A `derivedFields` rule on the Loki datasource extracts `traceId` from structured JSON logs and links directly to the corresponding Jaeger trace.
+- `LoggerService` injects `traceId` and `spanId` fields into every Winston log record via a dedicated format step that reads the active OpenTelemetry span context (`@opentelemetry/api`). The fields are omitted when no sampled span is active, so non-traced requests are unaffected.
 
 ## Implementation
 
@@ -80,7 +81,7 @@ With Loki provisioned, the Jaeger datasource in `grafana-config.yaml` is updated
 
 ### Environment: Kubernetes deployment order
 
-```
+```sh
 1. kubectl apply -f kubernetes/observability/loki/
 2. kubectl apply -f kubernetes/observability/promtail/
 3. kubectl apply -f kubernetes/observability/alertmanager/alertmanager-config.yaml
@@ -115,8 +116,9 @@ Receiver type is deployment-specific. Webhooks are the most portable default —
 ## Consequences
 
 - **Positive**: the observability triad is complete; Grafana Explore supports unified metrics + logs + traces correlation from a single query.
-- **Positive**: fired Prometheus alerts now reach an operator inbox instead of being silently dropped.
+- **Positive**: fired Prometheus alerts now reach an operator inbox instead of being silently dropped. Alertmanager uses `--config.expand-env=true` (v0.25+) to expand `${VAR}` placeholders in `alertmanager.yml` from container environment variables at start-up.
 - **Positive**: `tracesToLogsV2` in Grafana is now wired, enabling one-click navigation from a Jaeger trace span to the corresponding Loki log stream.
+- **Positive**: `derivedFields` in the Loki datasource is functional end-to-end: `LoggerService` now emits `traceId` and `spanId` on every log record produced within a sampled OTEL span, so log lines link directly back to Jaeger traces.
 - **Negative**: two additional PVCs (Loki 10 Gi, Alertmanager 2 Gi) are required in the cluster.
 - **Negative**: Promtail runs as root to read host log files. This is the expected and documented trade-off for log collection via hostPath; the blast radius is contained by a dedicated ServiceAccount with a minimal ClusterRole.
 - **Neutral**: Loki uses in-cluster filesystem storage. Log data is lost if the PVC is deleted. For production, migrate to object storage (GCS/S3) and enable the ruler component for alerting on log patterns.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,27 +27,28 @@ Each ADR follows this structure:
 
 <!-- adr-index:start -->
 
-| ADR                                                      | Title                                                                          | Status                           | Date       |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------- | ---------- |
-| [001](./001-node-js-25-native-typescript.md)             | Use Node.js 25 for Native TypeScript Support                                   | **Accepted** - November 20, 2025 | 2025-11-20 |
-| [002](./002-turborepo-monorepo.md)                       | Use Turborepo for Monorepo Management                                          | **Accepted** - November 20, 2025 | 2025-11-20 |
-| [003](./003-pnpm-package-manager.md)                     | Use pnpm as Package Manager                                                    | **Accepted** - November 20, 2025 | 2025-11-20 |
-| [004](./004-tsyringe-dependency-injection.md)            | Use TSyringe for Dependency Injection                                          | **Accepted** - November 20, 2025 | 2025-11-20 |
-| [005](./005-owasp-security-standards.md)                 | OWASP Security Standards and ESLint Plugin                                     | **Accepted** - November 20, 2025 | 2025-11-20 |
-| [006](./006-typescript-strict-mode.md)                   | TypeScript Strict Mode                                                         | **Accepted** - November 20, 2025 | 2025-11-20 |
-| [007](./007-passport-js-authentication.md)               | Passport.js Authentication Abstraction                                         | **Accepted** - November 20, 2025 | 2025-11-20 |
-| [008](./008-prisma-7-migration.md)                       | Migration to Prisma 7 with Adapter Pattern                                     | Accepted                         | 2025-11-26 |
-| [009](./009-artifact-registry-github-packages.md)        | Artifact registry — GitHub Packages (default), registry-agnostic publish flow  | Accepted                         | 2025-11-29 |
-| [010](./010-prisma-7-cli-migration-workaround.md)        | Prisma 7 CLI Migration Workaround Strategy                                     | Accepted                         | 2025-12-04 |
-| [011](./011-backend-only-auth.md)                        | Backend-Only Authentication                                                    | Accepted                         | 2025-12-16 |
-| [012](./012-testing-framework-vitest.md)                 | Use Vitest as the Primary Test Runner                                          | Accepted                         | 2026-02-02 |
-| [013](./013-correlation-ids-for-request-tracing.md)      | Correlation IDs for Request Tracing                                            | Accepted                         | 2026-02-05 |
-| [014](./014-e2e-personas-json-over-admin-ui.md)          | E2E Personas — JSON Overrides over Admin UI                                    | Accepted                         | 2026-02-06 |
-| [015](./015-prometheus-rules-management.md)              | Prometheus Rules Management (ConfigMap-mounted rule files)                     | Accepted                         | 2026-03-11 |
-| [016](./016-secure-by-default-prometheus-scraping.md)    | Secure-by-default Prometheus scraping (align scrape config with NetworkPolicy) | Accepted                         | 2026-03-11 |
-| [017](./017-grafana-loki-observability-stack.md)         | Grafana + Loki as the observability visualisation and log aggregation layer    | Accepted                         | 2026-03-20 |
-| [018](./018-infra-only-docker-local-dev.md)              | Infra-only Docker for Local Development and E2E Testing                        | Accepted                         | 2026-04-23 |
-| [019](./019-opentelemetry-jaeger-distributed-tracing.md) | OpenTelemetry SDK + Jaeger for Distributed Tracing                             | Accepted                         | 2026-04-24 |
+| ADR                                                      | Title                                                                              | Status                           | Date       |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------------------- | ---------- |
+| [001](./001-node-js-25-native-typescript.md)             | Use Node.js 25 for Native TypeScript Support                                       | **Accepted** - November 20, 2025 | 2025-11-20 |
+| [002](./002-turborepo-monorepo.md)                       | Use Turborepo for Monorepo Management                                              | **Accepted** - November 20, 2025 | 2025-11-20 |
+| [003](./003-pnpm-package-manager.md)                     | Use pnpm as Package Manager                                                        | **Accepted** - November 20, 2025 | 2025-11-20 |
+| [004](./004-tsyringe-dependency-injection.md)            | Use TSyringe for Dependency Injection                                              | **Accepted** - November 20, 2025 | 2025-11-20 |
+| [005](./005-owasp-security-standards.md)                 | OWASP Security Standards and ESLint Plugin                                         | **Accepted** - November 20, 2025 | 2025-11-20 |
+| [006](./006-typescript-strict-mode.md)                   | TypeScript Strict Mode                                                             | **Accepted** - November 20, 2025 | 2025-11-20 |
+| [007](./007-passport-js-authentication.md)               | Passport.js Authentication Abstraction                                             | **Accepted** - November 20, 2025 | 2025-11-20 |
+| [008](./008-prisma-7-migration.md)                       | Migration to Prisma 7 with Adapter Pattern                                         | Accepted                         | 2025-11-26 |
+| [009](./009-artifact-registry-github-packages.md)        | Artifact registry — GitHub Packages (default), registry-agnostic publish flow      | Accepted                         | 2025-11-29 |
+| [010](./010-prisma-7-cli-migration-workaround.md)        | Prisma 7 CLI Migration Workaround Strategy                                         | Accepted                         | 2025-12-04 |
+| [011](./011-backend-only-auth.md)                        | Backend-Only Authentication                                                        | Accepted                         | 2025-12-16 |
+| [012](./012-testing-framework-vitest.md)                 | Use Vitest as the Primary Test Runner                                              | Accepted                         | 2026-02-02 |
+| [013](./013-correlation-ids-for-request-tracing.md)      | Correlation IDs for Request Tracing                                                | Accepted                         | 2026-02-05 |
+| [014](./014-e2e-personas-json-over-admin-ui.md)          | E2E Personas — JSON Overrides over Admin UI                                        | Accepted                         | 2026-02-06 |
+| [015](./015-prometheus-rules-management.md)              | Prometheus Rules Management (ConfigMap-mounted rule files)                         | Accepted                         | 2026-03-11 |
+| [016](./016-secure-by-default-prometheus-scraping.md)    | Secure-by-default Prometheus scraping (align scrape config with NetworkPolicy)     | Accepted                         | 2026-03-11 |
+| [017](./017-grafana-loki-observability-stack.md)         | Grafana + Loki as the observability visualisation and log aggregation layer        | Accepted                         | 2026-03-20 |
+| [018](./018-infra-only-docker-local-dev.md)              | Infra-only Docker for Local Development and E2E Testing                            | Accepted                         | 2026-04-23 |
+| [019](./019-opentelemetry-jaeger-distributed-tracing.md) | OpenTelemetry SDK + Jaeger for Distributed Tracing                                 | Accepted                         | 2026-04-24 |
+| [020](./020-loki-promtail-alertmanager-observability.md) | Loki + Promtail for Centralized Log Aggregation and Alertmanager for Alert Routing | Accepted                         | 2026-05-20 |
 
 <!-- adr-index:end -->
 

--- a/kubernetes/observability/alertmanager/alertmanager-config.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-config.yaml
@@ -34,12 +34,12 @@ data:
       group_interval: 5m
       repeat_interval: 1h
       routes:
-        - match:
-            severity: critical
+        - matchers:
+            - severity="critical"
           receiver: critical-receiver
           continue: false
-        - match:
-            severity: warning
+        - matchers:
+            - severity="warning"
           receiver: warning-receiver
           continue: false
 
@@ -62,10 +62,10 @@ data:
     inhibit_rules:
       # Suppress warning-level alerts when a critical alert with the same
       # identity labels is already firing, reducing duplicate pages.
-      - source_match:
-          severity: critical
-        target_match:
-          severity: warning
+      - source_matchers:
+          - severity="critical"
+        target_matchers:
+          - severity="warning"
         equal:
           - alertname
           - cluster

--- a/kubernetes/observability/alertmanager/alertmanager-config.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-config.yaml
@@ -1,0 +1,72 @@
+# Alertmanager ConfigMap
+#
+# Default routing:
+#   - critical alerts → critical-receiver (webhook; URL supplied via secret env var)
+#   - warning alerts  → warning-receiver  (webhook; URL supplied via secret env var)
+#   - everything else → null receiver (silenced)
+#
+# Inhibition: a firing critical alert suppresses the corresponding warning alert
+# for the same {alertname, cluster, service} tuple to reduce notification noise.
+#
+# Replace the webhook receivers with PagerDuty, Slack, or email stanzas as
+# needed for each environment.  Keep this file receiver-type-agnostic and
+# inject credentials via the alertmanager-secret Secret.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-config
+  namespace: observability
+  labels:
+    app: alertmanager
+    component: alerting
+data:
+  alertmanager.yml: |
+    global:
+      resolve_timeout: 5m
+      # Optional: set a global SMTP or HTTP proxy here.
+
+    templates: []
+
+    route:
+      receiver: 'null'
+      group_by: ['alertname', 'cluster', 'service']
+      group_wait: 10s
+      group_interval: 5m
+      repeat_interval: 1h
+      routes:
+        - match:
+            severity: critical
+          receiver: critical-receiver
+          continue: false
+        - match:
+            severity: warning
+          receiver: warning-receiver
+          continue: false
+
+    receivers:
+      - name: 'null'
+        # Default sink — alerts that do not match any child route are silenced.
+
+      - name: critical-receiver
+        webhook_configs:
+          - url: '${ALERTMANAGER_CRITICAL_WEBHOOK_URL}'
+            send_resolved: true
+            http_config:
+              # Add bearer_token_file or TLS config here for authenticated endpoints.
+
+      - name: warning-receiver
+        webhook_configs:
+          - url: '${ALERTMANAGER_WARNING_WEBHOOK_URL}'
+            send_resolved: true
+
+    inhibit_rules:
+      # Suppress warning-level alerts when a critical alert with the same
+      # identity labels is already firing, reducing duplicate pages.
+      - source_match:
+          severity: critical
+        target_match:
+          severity: warning
+        equal:
+          - alertname
+          - cluster
+          - service

--- a/kubernetes/observability/alertmanager/alertmanager-deployment.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-deployment.yaml
@@ -1,8 +1,8 @@
 # Alertmanager Deployment, Service, and PersistentVolumeClaim
 #
 # Port: 9093 (HTTP API + UI used by Prometheus to route alerts)
-# Port: 9094 (cluster mesh — unused in single-replica dev mode; kept for
-#             operational parity with multi-replica HA configs)
+# Clustering is disabled via --cluster.listen-address= ; port 9094 is not
+# exposed.
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubernetes/observability/alertmanager/alertmanager-deployment.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-deployment.yaml
@@ -42,6 +42,9 @@ spec:
             - '--web.listen-address=:9093'
             - '--cluster.listen-address=' # disable HA clustering in single-replica mode
             - '--log.level=warn'
+            # Expand ${VAR} placeholders in alertmanager.yml from container env vars.
+            # Supported since Alertmanager v0.25; env vars are sourced from alertmanager-secret.
+            - '--config.expand-env=true'
           ports:
             - name: http
               containerPort: 9093
@@ -77,9 +80,11 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+              ephemeral-storage: 64Mi
             limits:
               cpu: 200m
               memory: 256Mi
+              ephemeral-storage: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/kubernetes/observability/alertmanager/alertmanager-deployment.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-deployment.yaml
@@ -1,0 +1,139 @@
+# Alertmanager Deployment, Service, and PersistentVolumeClaim
+#
+# Port: 9093 (HTTP API + UI used by Prometheus to route alerts)
+# Port: 9094 (cluster mesh — unused in single-replica dev mode; kept for
+#             operational parity with multi-replica HA configs)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alertmanager
+  namespace: observability
+  labels:
+    app: alertmanager
+    component: alerting
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alertmanager
+  template:
+    metadata:
+      labels:
+        app: alertmanager
+        component: alerting
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9093'
+        prometheus.io/path: '/metrics'
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      containers:
+        - name: alertmanager
+          image: quay.io/prometheus/alertmanager:v0.27.0
+          args:
+            - '--config.file=/etc/alertmanager/alertmanager.yml'
+            - '--storage.path=/alertmanager'
+            - '--web.listen-address=:9093'
+            - '--cluster.listen-address=' # disable HA clustering in single-replica mode
+            - '--log.level=warn'
+          ports:
+            - name: http
+              containerPort: 9093
+              protocol: TCP
+          env:
+            - name: ALERTMANAGER_CRITICAL_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: alertmanager-secret
+                  key: ALERTMANAGER_CRITICAL_WEBHOOK_URL
+            - name: ALERTMANAGER_WARNING_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: alertmanager-secret
+                  key: ALERTMANAGER_WARNING_WEBHOOK_URL
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alertmanager/alertmanager.yml
+              subPath: alertmanager.yml
+              readOnly: true
+            - name: storage
+              mountPath: /alertmanager
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: alertmanager-config
+        - name: storage
+          persistentVolumeClaim:
+            claimName: alertmanager-storage
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+  namespace: observability
+  labels:
+    app: alertmanager
+    component: alerting
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9093
+      targetPort: http
+      protocol: TCP
+  selector:
+    app: alertmanager
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: alertmanager-storage
+  namespace: observability
+  labels:
+    app: alertmanager
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: standard

--- a/kubernetes/observability/alertmanager/alertmanager-network-policy.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-network-policy.yaml
@@ -55,3 +55,15 @@ spec:
     - ports:
         - protocol: TCP
           port: 443
+    # Allow Istio control-plane communication (xDS/SDS config from istiod).
+    # Required when istio-injection: enabled is set on the namespace so the
+    # envoy sidecar can receive configuration and come up healthy.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15014

--- a/kubernetes/observability/alertmanager/alertmanager-network-policy.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-network-policy.yaml
@@ -1,0 +1,57 @@
+# NetworkPolicy for Alertmanager
+# Principle of least privilege:
+#   - Only Prometheus may push alerts to Alertmanager (port 9093).
+#   - Alertmanager may egress to the internet to fire webhook notifications.
+#   - Prometheus may scrape Alertmanager metrics (port 9093).
+#   - No other ingress is permitted.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager
+  namespace: observability
+  labels:
+    app: alertmanager
+    component: alerting-security
+spec:
+  podSelector:
+    matchLabels:
+      app: alertmanager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow Prometheus to send alerts and scrape metrics
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app: prometheus
+      ports:
+        - protocol: TCP
+          port: 9093
+    # Allow kubelet health probes via Istio sidecar status port
+    - ports:
+        - protocol: TCP
+          port: 15021
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow outbound HTTPS for webhook notifications (PagerDuty, Slack, etc.)
+    # Restrict this to specific CIDRs in production if egress filtering is available.
+    - ports:
+        - protocol: TCP
+          port: 443

--- a/kubernetes/observability/alertmanager/alertmanager-secret.example.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-secret.example.yaml
@@ -1,0 +1,24 @@
+# Alertmanager Secret — example / template
+#
+# Copy this file to alertmanager-secret.yaml, fill in real values, and apply
+# it manually.  Do NOT commit the populated file to version control.
+#
+# The Deployment mounts these keys as environment variables so that the
+# alertmanager.yml ConfigMap can reference them via ${VAR} substitution.
+# Alertmanager itself does not perform env-var substitution natively;
+# if using a static config, inject the URLs directly into the ConfigMap
+# through a CI pipeline secret or external-secrets operator instead.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-secret
+  namespace: observability
+  labels:
+    app: alertmanager
+    component: alerting
+type: Opaque
+stringData:
+  # Webhook URL for critical alerts (replace with your actual endpoint)
+  ALERTMANAGER_CRITICAL_WEBHOOK_URL: 'https://hooks.example.com/critical'
+  # Webhook URL for warning alerts (replace with your actual endpoint)
+  ALERTMANAGER_WARNING_WEBHOOK_URL: 'https://hooks.example.com/warning'

--- a/kubernetes/observability/alertmanager/alertmanager-secret.example.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-secret.example.yaml
@@ -6,7 +6,6 @@
 # The Deployment mounts these keys as environment variables.  The
 # alertmanager.yml ConfigMap references them via ${VAR} placeholders, which
 # are expanded at start-up by the --config.expand-env=true flag (v0.25+).
-# Do NOT commit the populated file to version control.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/kubernetes/observability/alertmanager/alertmanager-secret.example.yaml
+++ b/kubernetes/observability/alertmanager/alertmanager-secret.example.yaml
@@ -3,11 +3,10 @@
 # Copy this file to alertmanager-secret.yaml, fill in real values, and apply
 # it manually.  Do NOT commit the populated file to version control.
 #
-# The Deployment mounts these keys as environment variables so that the
-# alertmanager.yml ConfigMap can reference them via ${VAR} substitution.
-# Alertmanager itself does not perform env-var substitution natively;
-# if using a static config, inject the URLs directly into the ConfigMap
-# through a CI pipeline secret or external-secrets operator instead.
+# The Deployment mounts these keys as environment variables.  The
+# alertmanager.yml ConfigMap references them via ${VAR} placeholders, which
+# are expanded at start-up by the --config.expand-env=true flag (v0.25+).
+# Do NOT commit the populated file to version control.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/kubernetes/observability/grafana/grafana-config.yaml
+++ b/kubernetes/observability/grafana/grafana-config.yaml
@@ -43,12 +43,13 @@ data:
             filterBySpanID: false
             customQuery: false
             tags:
-              - key: app
+              # Map the OTel resource attribute service.name (set by TracingService
+              # via ATTR_SERVICE_NAME) to the Loki 'app' label (set by Promtail
+              # from the pod's app label).  namespace/pod attributes are omitted
+              # because no K8s resource detector or OTEL_RESOURCE_ATTRIBUTES is
+              # configured; filterByTraceID provides the primary log correlation.
+              - key: service.name
                 value: app
-              - key: namespace
-                value: namespace
-              - key: pod
-                value: pod
 
       - name: Loki
         type: loki

--- a/kubernetes/observability/grafana/grafana-config.yaml
+++ b/kubernetes/observability/grafana/grafana-config.yaml
@@ -60,9 +60,11 @@ data:
           maxLines: 1000
           derivedFields:
             # Automatically link Loki log lines containing a traceId to Jaeger.
+            # matcherRegex captures exactly 32 lowercase hex chars — the
+            # canonical OTel 128-bit trace ID format emitted by LoggerService.
             - name: TraceID
-              matcherRegex: '"traceId":"(\w+)"'
-              url: '$${__value.raw}'
+              matcherRegex: '"traceId":"([0-9a-f]{32})"'
+              url: '${__value.raw}'
               datasourceUid: jaeger
               urlDisplayLabel: 'View Trace in Jaeger'
 

--- a/kubernetes/observability/grafana/grafana-config.yaml
+++ b/kubernetes/observability/grafana/grafana-config.yaml
@@ -33,10 +33,38 @@ data:
         url: http://jaeger:16686
         editable: false
         jsonData:
-          # tracesToLogsV2 wiring is intentionally deferred until Loki datasource
-          # is provisioned in this environment.
           nodeGraph:
             enabled: true
+          tracesToLogsV2:
+            datasourceUid: loki
+            spanStartTimeShift: '-5m'
+            spanEndTimeShift: '5m'
+            filterByTraceID: true
+            filterBySpanID: false
+            customQuery: false
+            tags:
+              - key: app
+                value: app
+              - key: namespace
+                value: namespace
+              - key: pod
+                value: pod
+
+      - name: Loki
+        type: loki
+        uid: loki
+        access: proxy
+        url: http://loki:3100
+        editable: false
+        jsonData:
+          maxLines: 1000
+          derivedFields:
+            # Automatically link Loki log lines containing a traceId to Jaeger.
+            - name: TraceID
+              matcherRegex: '"traceId":"(\w+)"'
+              url: '$${__value.raw}'
+              datasourceUid: jaeger
+              urlDisplayLabel: 'View Trace in Jaeger'
 
   dashboards.yaml: |
     apiVersion: 1

--- a/kubernetes/observability/grafana/grafana-network-policy.yaml
+++ b/kubernetes/observability/grafana/grafana-network-policy.yaml
@@ -62,3 +62,14 @@ spec:
       ports:
         - protocol: TCP
           port: 16686
+    # Allow Grafana to query Loki datasource
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app: loki
+      ports:
+        - protocol: TCP
+          port: 3100

--- a/kubernetes/observability/loki/loki-config.yaml
+++ b/kubernetes/observability/loki/loki-config.yaml
@@ -1,0 +1,74 @@
+# Loki ConfigMap — single-binary (monolithic) mode
+#
+# Suitable for development and staging clusters.
+# For production, switch to the microservices deployment mode backed by
+# object storage (GCS, S3, or Azure Blob) and remove the filesystem stanzas.
+#
+# Port: 3100 (HTTP API + push endpoint used by Promtail and Grafana)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: observability
+  labels:
+    app: loki
+    component: logging
+data:
+  loki.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+      log_level: warn
+
+    common:
+      instance_addr: 0.0.0.0
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+
+    limits_config:
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h  # 7 days
+      # Retention is enforced by the compactor; 31-day default suits dev/staging.
+      retention_period: 744h
+
+    compactor:
+      working_directory: /loki/compactor
+      retention_enabled: true
+      delete_request_store: filesystem
+
+    ingester:
+      chunk_idle_period: 10m
+      chunk_retain_period: 30s
+      max_transfer_retries: 0
+      wal:
+        enabled: true
+        dir: /loki/wal
+
+    query_range:
+      results_cache:
+        cache:
+          embedded_cache:
+            enabled: true
+            max_size_mb: 100
+
+    analytics:
+      reporting_enabled: false

--- a/kubernetes/observability/loki/loki-deployment.yaml
+++ b/kubernetes/observability/loki/loki-deployment.yaml
@@ -41,9 +41,6 @@ spec:
             - name: http
               containerPort: 3100
               protocol: TCP
-            - name: grpc
-              containerPort: 9096
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: /ready
@@ -108,10 +105,6 @@ spec:
     - name: http
       port: 3100
       targetPort: http
-      protocol: TCP
-    - name: grpc
-      port: 9096
-      targetPort: grpc
       protocol: TCP
   selector:
     app: loki

--- a/kubernetes/observability/loki/loki-deployment.yaml
+++ b/kubernetes/observability/loki/loki-deployment.yaml
@@ -1,0 +1,132 @@
+# Loki Deployment, Service, and PersistentVolumeClaim
+#
+# Single-binary mode; safe for development / staging.
+# Exposes port 3100 (HTTP) consumed by Promtail (log push) and Grafana (query).
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: observability
+  labels:
+    app: loki
+    component: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+        component: logging
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '3100'
+        prometheus.io/path: '/metrics'
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: loki
+          image: grafana/loki:3.0.0
+          args:
+            - '-config.file=/etc/loki/loki.yaml'
+          ports:
+            - name: http
+              containerPort: 3100
+              protocol: TCP
+            - name: grpc
+              containerPort: 9096
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki/loki.yaml
+              subPath: loki.yaml
+              readOnly: true
+            - name: storage
+              mountPath: /loki
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+        - name: storage
+          persistentVolumeClaim:
+            claimName: loki-storage
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: observability
+  labels:
+    app: loki
+    component: logging
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+      protocol: TCP
+    - name: grpc
+      port: 9096
+      targetPort: grpc
+      protocol: TCP
+  selector:
+    app: loki
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-storage
+  namespace: observability
+  labels:
+    app: loki
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: standard

--- a/kubernetes/observability/loki/loki-network-policy.yaml
+++ b/kubernetes/observability/loki/loki-network-policy.yaml
@@ -1,6 +1,6 @@
 # NetworkPolicy for Loki
 # Principle of least privilege:
-#   - Only Promtail (in any namespace, identified by label) may push logs.
+#   - Only Promtail (in the observability namespace) may push logs.
 #   - Only Grafana (observability namespace) may query the Loki HTTP API.
 #   - Prometheus may scrape the /metrics endpoint.
 #   - No external egress required (filesystem storage, in-cluster ring).

--- a/kubernetes/observability/loki/loki-network-policy.yaml
+++ b/kubernetes/observability/loki/loki-network-policy.yaml
@@ -1,0 +1,74 @@
+# NetworkPolicy for Loki
+# Principle of least privilege:
+#   - Only Promtail (in any namespace, identified by label) may push logs.
+#   - Only Grafana (observability namespace) may query the Loki HTTP API.
+#   - Prometheus may scrape the /metrics endpoint.
+#   - No external egress required (filesystem storage, in-cluster ring).
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: loki
+  namespace: observability
+  labels:
+    app: loki
+    component: logging-security
+spec:
+  podSelector:
+    matchLabels:
+      app: loki
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow Promtail (runs in observability namespace as a DaemonSet) to push logs
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app: promtail
+      ports:
+        - protocol: TCP
+          port: 3100
+    # Allow Grafana to query Loki
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app: grafana
+      ports:
+        - protocol: TCP
+          port: 3100
+    # Allow Prometheus to scrape Loki metrics
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app: prometheus
+      ports:
+        - protocol: TCP
+          port: 3100
+    # Allow kubelet health probes via Istio sidecar status port
+    - ports:
+        - protocol: TCP
+          port: 15021
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/kubernetes/observability/loki/loki-network-policy.yaml
+++ b/kubernetes/observability/loki/loki-network-policy.yaml
@@ -72,3 +72,15 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    # Allow Istio control-plane communication (xDS/SDS config from istiod).
+    # Required when istio-injection: enabled is set on the namespace so the
+    # envoy sidecar can receive configuration and come up healthy.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15014

--- a/kubernetes/observability/prometheus-config.yaml
+++ b/kubernetes/observability/prometheus-config.yaml
@@ -14,12 +14,12 @@ data:
         cluster: 'next-node-app-base'
         environment: 'development'
 
-    # Alertmanager configuration (disabled by default; enable when Alertmanager is deployed)
-    # alerting:
-    #   alertmanagers:
-    #     - static_configs:
-    #         - targets:
-    #           - alertmanager:9093
+    # Alertmanager configuration
+    alerting:
+      alertmanagers:
+        - static_configs:
+            - targets:
+                - alertmanager:9093
 
     # Load rules once and periodically evaluate them
     rule_files:
@@ -76,7 +76,7 @@ data:
           # Constrain scrape ports to align with the Prometheus NetworkPolicy egress allowlist.
           - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
             action: keep
-            regex: (8080|9090|15090|3000|14269)
+            regex: (8080|9080|9090|9093|15090|3000|3100|14269)
           - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
             action: replace
             target_label: __metrics_path__

--- a/kubernetes/observability/prometheus-network-policy.yaml
+++ b/kubernetes/observability/prometheus-network-policy.yaml
@@ -108,3 +108,15 @@ spec:
       ports:
         - protocol: TCP
           port: 443
+    # Allow Istio control-plane communication (xDS/SDS config from istiod).
+    # Required when istio-injection: enabled is set on the namespace so the
+    # envoy sidecar can receive configuration and come up healthy.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15014

--- a/kubernetes/observability/prometheus-network-policy.yaml
+++ b/kubernetes/observability/prometheus-network-policy.yaml
@@ -67,7 +67,13 @@ spec:
         - protocol: TCP
           port: 8080
         - protocol: TCP
+          port: 9080 # Promtail metrics
+        - protocol: TCP
           port: 3000
+        - protocol: TCP
+          port: 3100 # Loki metrics
+        - protocol: TCP
+          port: 9093 # Alertmanager metrics
         - protocol: TCP
           port: 15090 # Istio Envoy metrics
         - protocol: TCP
@@ -85,6 +91,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    # Allow Prometheus to send alerts to Alertmanager
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app: alertmanager
+      ports:
+        - protocol: TCP
+          port: 9093
     # Allow Kubernetes API access for service discovery and node metrics proxy scraping
     - to:
         - namespaceSelector: {}

--- a/kubernetes/observability/promtail/promtail-daemonset.yaml
+++ b/kubernetes/observability/promtail/promtail-daemonset.yaml
@@ -31,12 +31,13 @@ metadata:
     app: promtail
     component: logging
 rules:
+  # Minimal permissions for kubernetes_sd_configs role: pod.
+  # nodes — required for pod-to-node metadata (__meta_kubernetes_pod_node_name).
+  # pods  — required for pod discovery and label/annotation metadata.
+  # nodes/proxy, services, and endpoints are not needed for pod-role SD.
   - apiGroups: ['']
     resources:
       - nodes
-      - nodes/proxy
-      - services
-      - endpoints
       - pods
     verbs: ['get', 'watch', 'list']
 ---

--- a/kubernetes/observability/promtail/promtail-daemonset.yaml
+++ b/kubernetes/observability/promtail/promtail-daemonset.yaml
@@ -177,9 +177,11 @@ spec:
             requests:
               cpu: 50m
               memory: 64Mi
+              ephemeral-storage: 64Mi
             limits:
               cpu: 200m
               memory: 256Mi
+              ephemeral-storage: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/kubernetes/observability/promtail/promtail-daemonset.yaml
+++ b/kubernetes/observability/promtail/promtail-daemonset.yaml
@@ -107,13 +107,13 @@ data:
             target_label: app
           - source_labels: [__meta_kubernetes_pod_label_component]
             target_label: component
-          # Build the log path from the discovered pod UID and container name.
+          # Build the log path from the discovered pod UID.  The /*/ wildcard
+          # covers the per-container subdirectory that kubelet creates under
+          # /var/log/pods/<namespace>_<pod-name>_<uid>/<container>/<n>.log.
           - source_labels:
               - __meta_kubernetes_pod_uid
-              - __meta_kubernetes_pod_container_name
             target_label: __path__
-            separator: /
-            replacement: /var/log/pods/*$1/*.log
+            replacement: /var/log/pods/*$1/*/*.log
           # Carry through the correlation ID label when it is set on the pod.
           - source_labels: [__meta_kubernetes_pod_annotation_correlation_id]
             target_label: correlation_id

--- a/kubernetes/observability/promtail/promtail-daemonset.yaml
+++ b/kubernetes/observability/promtail/promtail-daemonset.yaml
@@ -1,0 +1,210 @@
+# Promtail — RBAC, ServiceAccount, ConfigMap, DaemonSet
+#
+# Promtail runs as a DaemonSet on every node so that it can tail container
+# logs from /var/log/pods on the host.  It pushes structured log lines to
+# Loki over HTTP (port 3100).
+#
+# Security notes:
+#   - hostPath mounts are read-only and scoped to /var/log and /run/promtail.
+#   - The container runs as root because kubelet writes logs with root
+#     ownership.  The ServiceAccount token is auto-mounted for Kubernetes
+#     service-discovery only; the ClusterRole grants read access to pods and
+#     nodes metadata only.
+#   - allowPrivilegeEscalation is disabled; CAP_DAC_READ_SEARCH is added so
+#     Promtail can read files owned by other users on the host filesystem.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: observability
+  labels:
+    app: promtail
+    component: logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+  labels:
+    app: promtail
+    component: logging
+rules:
+  - apiGroups: ['']
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs: ['get', 'watch', 'list']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+  labels:
+    app: promtail
+    component: logging
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: observability
+roleRef:
+  kind: ClusterRole
+  name: promtail
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: observability
+  labels:
+    app: promtail
+    component: logging
+data:
+  promtail.yaml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+      log_level: warn
+
+    positions:
+      filename: /run/promtail/positions.yaml
+
+    clients:
+      - url: http://loki:3100/loki/api/v1/push
+        # Batch settings — keep defaults; tune for high-volume clusters.
+        batchwait: 1s
+        batchsize: 1048576
+
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        pipeline_stages:
+          # Parse the CRI log format emitted by containerd / CRI-O.
+          - cri: {}
+          # Drop probe / health-check spam so Loki does not fill up with noise.
+          - drop:
+              expression: '(?i)(GET /health|GET /ready|GET /metrics|kube-probe)'
+              drop_counter_reason: health_probe_drop
+        relabel_configs:
+          # Only scrape pods that have not opted out.
+          - source_labels: [__meta_kubernetes_pod_annotation_promtail_io_scrape]
+            action: drop
+            regex: 'false'
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: __host__
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            target_label: container
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: app
+          - source_labels: [__meta_kubernetes_pod_label_component]
+            target_label: component
+          # Build the log path from the discovered pod UID and container name.
+          - source_labels:
+              - __meta_kubernetes_pod_uid
+              - __meta_kubernetes_pod_container_name
+            target_label: __path__
+            separator: /
+            replacement: /var/log/pods/*$1/*.log
+          # Carry through the correlation ID label when it is set on the pod.
+          - source_labels: [__meta_kubernetes_pod_annotation_correlation_id]
+            target_label: correlation_id
+            regex: (.+)
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: observability
+  labels:
+    app: promtail
+    component: logging
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: promtail
+        component: logging
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9080'
+        prometheus.io/path: '/metrics'
+    spec:
+      serviceAccountName: promtail
+      # Promtail must run as root to read host container logs written by kubelet.
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      tolerations:
+        # Tolerate all taints so Promtail runs on every node, including control-plane nodes.
+        - operator: Exists
+          effect: NoSchedule
+        - operator: Exists
+          effect: NoExecute
+      containers:
+        - name: promtail
+          image: grafana/promtail:3.0.0
+          args:
+            - '-config.file=/etc/promtail/promtail.yaml'
+          ports:
+            - name: http
+              containerPort: 9080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                # Required to read log files owned by the kubelet user on the host.
+                - DAC_READ_SEARCH
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail/promtail.yaml
+              subPath: promtail.yaml
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: positions
+              mountPath: /run/promtail
+      volumes:
+        - name: config
+          configMap:
+            name: promtail-config
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: positions
+          emptyDir: {}

--- a/kubernetes/observability/promtail/promtail-daemonset.yaml
+++ b/kubernetes/observability/promtail/promtail-daemonset.yaml
@@ -201,6 +201,8 @@ spec:
               readOnly: true
             - name: positions
               mountPath: /run/promtail
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: config
           configMap:
@@ -209,4 +211,6 @@ spec:
           hostPath:
             path: /var/log
         - name: positions
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}

--- a/kubernetes/observability/promtail/promtail-daemonset.yaml
+++ b/kubernetes/observability/promtail/promtail-daemonset.yaml
@@ -5,7 +5,8 @@
 # Loki over HTTP (port 3100).
 #
 # Security notes:
-#   - hostPath mounts are read-only and scoped to /var/log and /run/promtail.
+#   - The /var/log hostPath mount is read-only.  /run/promtail (positions
+#     file) is backed by an emptyDir volume, not a hostPath.
 #   - The container runs as root because kubelet writes logs with root
 #     ownership.  The ServiceAccount token is auto-mounted for Kubernetes
 #     service-discovery only; the ClusterRole grants read access to pods and

--- a/kubernetes/observability/promtail/promtail-network-policy.yaml
+++ b/kubernetes/observability/promtail/promtail-network-policy.yaml
@@ -61,9 +61,10 @@ spec:
       ports:
         - protocol: TCP
           port: 3100
-    # Allow Kubernetes API for pod/node service-discovery
-    - to:
-        - namespaceSelector: {}
-      ports:
+    # Allow Kubernetes API for pod/node service-discovery.
+    # No 'to:' selector: kube-apiserver is accessed via a ClusterIP Service
+    # (kubernetes.default.svc) whose endpoint IP is not a pod, so a
+    # namespaceSelector/podSelector would silently block the traffic.
+    - ports:
         - protocol: TCP
           port: 443

--- a/kubernetes/observability/promtail/promtail-network-policy.yaml
+++ b/kubernetes/observability/promtail/promtail-network-policy.yaml
@@ -1,0 +1,69 @@
+# NetworkPolicy for Promtail
+# Promtail runs as a DaemonSet and needs:
+#   - Egress to Loki (port 3100) to push logs.
+#   - Egress to the Kubernetes API (443) for pod/node service-discovery.
+#   - Ingress from Prometheus (port 9080) for metrics scraping.
+#   - No ingress from untrusted sources.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: promtail
+  namespace: observability
+  labels:
+    app: promtail
+    component: logging-security
+spec:
+  podSelector:
+    matchLabels:
+      app: promtail
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow Prometheus to scrape Promtail metrics
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app: prometheus
+      ports:
+        - protocol: TCP
+          port: 9080
+    # Allow kubelet health probes via Istio sidecar status port
+    - ports:
+        - protocol: TCP
+          port: 15021
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow log push to Loki
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+          podSelector:
+            matchLabels:
+              app: loki
+      ports:
+        - protocol: TCP
+          port: 3100
+    # Allow Kubernetes API for pod/node service-discovery
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443

--- a/kubernetes/observability/promtail/promtail-network-policy.yaml
+++ b/kubernetes/observability/promtail/promtail-network-policy.yaml
@@ -68,3 +68,15 @@ spec:
     - ports:
         - protocol: TCP
           port: 443
+    # Allow Istio control-plane communication (xDS/SDS config from istiod).
+    # Required when istio-injection: enabled is set on the namespace so the
+    # envoy sidecar can receive configuration and come up healthy.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15014


### PR DESCRIPTION
# Pull Request

## Summary

Completes **Phase 10 observability** by adding structured log aggregation, alert routing, and full bidirectional trace ↔ log correlation in Grafana. Builds on PR #51 (Jaeger/OTEL tracing).

### New infrastructure

| Component | Image | Role |
|---|---|---|
| **Loki** | `grafana/loki:3.0.0` | Single-binary log aggregation, TSDB v13 schema, 31-day retention, 10 Gi PVC |
| **Promtail** | `grafana/promtail:3.0.0` | DaemonSet log collector — tails `/var/log/pods`, CRI pipeline, enriches labels with `namespace`/`pod`/`container`/`app`/`correlation_id` |
| **Alertmanager** | `quay.io/prometheus/alertmanager:v0.27.0` | Routes fired Prometheus alerts to critical/warning webhook receivers; `--config.expand-env=true` expands `${VAR}` placeholders from container env |

### Grafana wiring

- Loki datasource provisioned (`http://loki:3100`, `maxLines: 1000`).
- `derivedFields` on Loki extracts `traceId` from JSON log bodies via `"traceId":"([0-9a-f]{32})"` and links to the corresponding Jaeger trace.
- Jaeger datasource updated with `tracesToLogsV2`: ±5 min time shift, `service.name → app` label mapping, `filterByTraceID: true`. Tag mapping uses only `service.name` (the only OTel resource attribute set by `TracingService`); `namespace`/`pod` were removed as they are never emitted by the backend tracer.
- Grafana network policy extended: Loki port 3100 egress + Istio control-plane egress (TCP 15012/15014).

### Prometheus updates

- `alerting.alertmanagers` stanza activated pointing to `alertmanager:9093`.
- Scrape port allowlist extended: Promtail (9080), Loki (3100), Alertmanager (9093).
- Network policy extended with matching egress rules and Istio control-plane egress.

### Backend logger

- `LoggerService` gains an `injectTraceContext` Winston format step that reads `trace.getActiveSpan()?.spanContext()` via `@opentelemetry/api` and writes `traceId` + `spanId` into every log record when a sampled span is active. Degrades gracefully to a no-op when tracing is disabled.
- 3 new unit tests cover all branches: sampled span present, no active span, and unsampled span (total: 10 backend tests).

### Security & RBAC hardening (applied during review)

- Promtail `ClusterRole` narrowed to `pods` + `nodes` only (removed `nodes/proxy`, `services`, `endpoints` — not needed for `role: pod` SD).
- Promtail kube-apiserver egress: `to:` selector removed (kube-apiserver ClusterIP is unreachable via `namespaceSelector`; open TCP/443 egress is correct).
- Promtail `/tmp` `emptyDir` volume added (required for Go runtime with `readOnlyRootFilesystem: true`).
- Promtail `__path__` glob fixed to `/var/log/pods/*$1/*/*.log` (adds container-directory wildcard matching the actual kubelet log layout).
- Alertmanager deprecated `match:`/`source_match:`/`target_match:` keys replaced with v0.27 `matchers:`/`source_matchers:`/`target_matchers:`.
- `kubernetes/observability/alertmanager/alertmanager-secret.yaml` added to `.gitignore`.
- Istio sidecar egress (TCP 15012 xDS + 15014 SDS) added to all five network policies (Loki, Promtail, Alertmanager, Grafana, Prometheus) — the `observability` namespace has `istio-injection: enabled`; without these rules the envoy sidecar cannot bootstrap.
- Loki gRPC port 9096 removed from `Deployment` and `Service` (not used in single-binary mode; inconsistent with the NetworkPolicy).

### ADR

`docs/adr/020-loki-promtail-alertmanager-observability.md` records component selection, RBAC rationale, security trade-offs, and deployment order.

### Deployment order (first apply)

```sh
kubectl apply -f kubernetes/observability/loki/
kubectl apply -f kubernetes/observability/promtail/
kubectl apply -f kubernetes/observability/alertmanager/alertmanager-config.yaml
kubectl apply -f kubernetes/observability/alertmanager/alertmanager-secret.yaml   # copy from .example, do not commit
kubectl apply -f kubernetes/observability/alertmanager/alertmanager-deployment.yaml
kubectl apply -f kubernetes/observability/alertmanager/alertmanager-network-policy.yaml
kubectl apply -f kubernetes/observability/grafana/grafana-config.yaml
kubectl apply -f kubernetes/observability/grafana/grafana-network-policy.yaml
kubectl apply -f kubernetes/observability/prometheus-config.yaml
kubectl apply -f kubernetes/observability/prometheus-network-policy.yaml
kubectl rollout restart deployment/grafana deployment/prometheus -n observability
```

## Testing

- `pnpm --filter backend tsc --noEmit` — passes clean.
- `vitest run` (backend) — 10 tests pass, 0 failures (includes 3 new `injectTraceContext` branch tests).
- Pre-commit hooks (lint-staged + commitlint) passed on all commits.
- Kubernetes manifests validated with `kubectl apply --dry-run=client` across all 19 changed manifests.
- `derivedFields` regex `"traceId":"([0-9a-f]{32})"` verified against sample structured log output with an active OTEL span.
- All 18 Copilot review threads addressed and resolved across 7 review rounds.

## Checklist

- [ ] CI is green
- [ ] No secrets added/printed