### PR TITLE
chore(release): add Changesets versioning

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -8,4 +8,4 @@ pnpm changeset
 
 Choose each affected package, select the semantic version bump, and describe the user-visible change. Documentation, tests, CI, and repository-only maintenance do not require a changeset.
 
-After changesets reach `master`, the Version Packages workflow opens or updates a release pull request. Merging that pull request updates package versions and package changelogs; publishing remains an explicit action through the existing Publish Packages workflow.
+When you are ready to prepare a release, run the Version Packages workflow manually from GitHub Actions. It opens or updates a release pull request from the changesets accumulated on `master`. Merging that pull request updates package versions and package changelogs; publishing remains an explicit action through the existing Publish Packages workflow.

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,11 @@
+# Changesets
+
+Add a changeset for every pull request that changes a workspace package's public behavior:
+
+```bash
+pnpm changeset
+```
+
+Choose each affected package, select the semantic version bump, and describe the user-visible change. Documentation, tests, CI, and repository-only maintenance do not require a changeset.
+
+After changesets reach `master`, the Version Packages workflow opens or updates a release pull request. Merging that pull request updates package versions and package changelogs; publishing remains an explicit action through the existing Publish Packages workflow.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "master",
+  "updateInternalDependencies": "patch",
+  "ignore": [],
+  "privatePackages": {
+    "version": true,
+    "tag": false
+  }
+}

--- a/.github/prompts/plan-nextNodeAppBase.prompt.md
+++ b/.github/prompts/plan-nextNodeAppBase.prompt.md
@@ -456,13 +456,18 @@ Consequence: lower migration risk and clearer package boundaries.
   - Orphaned `node_modules/turbo-windows-64` directory (root cause of v1.13.4 ghost resolution) removed.
   - ADR-003 and `CONTRIBUTING.md` updated to document corepack hash discipline.
 
+- ✅ `chore/e2e-personas-moderator` merged to master as PR [#64](https://github.com/apkasten906/next-node-app-base/pull/64) (July 31, 2026; merge commit `cda412f`).
+  - Deterministic `moderator` fixtures and `MODERATOR` seed/login support added across backend and frontend.
+  - Unit coverage validates defaults, role validation, normalization, and frontend seed payloads.
+  - `@ready @impl_e2e_moderator_persona` BDD coverage validates seed upserts, fixture parity, and fallback authentication.
+  - ADR, BDD governance, lint, backend, and cross-platform E2E CI checks passed.
+
 ### Next priority (in order)
 
-1. **BDD base-repo scenario coverage** — complete for tracked base slices. Adopter-only frontend/security guidance is explicitly tagged `@wip @adopter`. Current governance totals are backend 140/266 ready, frontend 31/121 ready, and 171/387 overall.
-2. **E2E personas moderator** (branch: `chore/e2e-personas-moderator`) — implementation, unit tests, and `@ready @impl_e2e_moderator_persona` BDD contract coverage are complete in draft PR [#64](https://github.com/apkasten906/next-node-app-base/pull/64). All required CI checks are green; the PR now awaits review and merge.
-3. **Automated semantic versioning (Changesets)** — conventional commits are enforced by commitlint and `conventional-changelog-conventionalcommits` is already installed; the missing piece is a version-bump + CHANGELOG automation tool. Adopt `@changesets/cli` (natural fit for pnpm workspaces — versions packages independently), add a `chore/changesets-setup` GitHub Actions workflow that opens a "Version Packages" PR on merge to master, and catch up the stale `CHANGELOG.md` entries for all 2026 phases. Gate on: contract package extraction is not a blocker, but activate before the first real publish of `@repo/types` / `@repo/contracts`.
-4. **Contract package extraction** (Migration Plan step 6) — first bootstrapped fork will be `fasciculum-instrumentorum`; promote stable DTOs from `lib/contracts/` into `@repo/types` or a successor `@repo/contracts` package once that fork proves reuse.
-5. **Phase 11 Feature Management System** — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks. No code exists yet; begin with ADR and interface contracts in `packages/types`.
+- ✅ **Automated semantic versioning (Changesets)** — `@changesets/cli`, private-package versioning config, an immutable-action-pinned Version Packages PR workflow, current 2026 changelog entries, and publishing guidance are complete. Publishing remains explicitly gated by the existing Publish Packages workflow.
+
+1. **Contract package extraction** (Migration Plan step 6) — first bootstrapped fork will be `fasciculum-instrumentorum`; promote stable DTOs from `lib/contracts/` into `@repo/types` or a successor `@repo/contracts` package once that fork proves reuse.
+2. **Phase 11 Feature Management System** — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks. No code exists yet; begin with ADR and interface contracts in `packages/types`.
 
 ## N. BDD Scenario Scope: Base Repo vs Adopter
 
@@ -519,4 +524,4 @@ The `@ready` tag tracks only base-repo scenarios. Adopter scenarios stay `@wip @
 - **Frontend error-handling first batch complete**: `@impl_frontend_global_error_boundary`, `@impl_frontend_not_found_page`, `@impl_frontend_error_page`, `@impl_frontend_error_recovery`, `@impl_frontend_error_logging`, and `@impl_frontend_accessible_errors` are now `@ready`.
 - **Frontend core expanded batch complete**: `@impl_frontend_typed_api_client`, `@impl_frontend_error_boundary_recovery`, `@impl_frontend_loading_state`, `@impl_frontend_debounce_hook`, `@impl_frontend_query_caching`, `@impl_frontend_offline_detection`, `@impl_frontend_semantic_accessibility`, `@impl_frontend_keyboard_navigation`, and `@impl_frontend_form_validation` are now `@ready`.
 - **Frontend base complete**: final Next.js scenarios for responsive layout, route-level authentication, custom error pages, and loading UI are now `@ready`; remaining frontend scenarios are explicitly `@adopter`.
-- **Final classification cleanup complete**: adopter-only frontend/security scenarios are tagged `@adopter` and stay `@wip`. E2E personas moderator implementation and BDD coverage are complete in PR #64 with green CI, awaiting review and merge.
+- **Final classification cleanup complete**: adopter-only frontend/security scenarios are tagged `@adopter` and stay `@wip`. E2E personas moderator implementation and BDD coverage merged in PR #64 with green CI.

--- a/.github/prompts/plan-nextNodeAppBase.prompt.md
+++ b/.github/prompts/plan-nextNodeAppBase.prompt.md
@@ -464,7 +464,7 @@ Consequence: lower migration risk and clearer package boundaries.
 
 ### Next priority (in order)
 
-- ✅ **Automated semantic versioning (Changesets)** — `@changesets/cli`, private-package versioning config, an immutable-action-pinned Version Packages PR workflow, current 2026 changelog entries, and publishing guidance are complete. Publishing remains explicitly gated by the existing Publish Packages workflow.
+- ✅ **Review-driven semantic versioning (Changesets)** — `@changesets/cli`, private-package versioning config, a manually triggered and immutable-action-pinned Version Packages PR workflow, current 2026 changelog entries, and publishing guidance are complete. Version preparation and publishing remain explicit operator actions.
 
 1. **Contract package extraction** (Migration Plan step 6) — first bootstrapped fork will be `fasciculum-instrumentorum`; promote stable DTOs from `lib/contracts/` into `@repo/types` or a successor `@repo/contracts` package once that fork proves reuse.
 2. **Phase 11 Feature Management System** — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks. No code exists yet; begin with ADR and interface contracts in `packages/types`.

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -1,0 +1,38 @@
+name: Version Packages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: version-packages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  version-packages:
+    name: Open or update version PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: 25.x
+          install: "true"
+
+      - name: Create Version Packages pull request
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        with:
+          version: pnpm version:packages
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -1,8 +1,6 @@
 name: Version Packages
 
 on:
-  push:
-    branches: [master]
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BDD governance enforcement, implementation audits, and complete base-repository scenario coverage
 - Prometheus, Grafana, Jaeger, Loki, Promtail, and Alertmanager observability infrastructure
 - OpenTelemetry tracing, structured trace/log correlation, dashboards, alerts, and observability network policies
-- Automated Changesets version pull requests for workspace package versioning and changelogs
+- Manually triggered Changesets version pull requests for workspace package versioning and changelogs
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `.nvmrc` to Node.js 25
 - Updated Dev Container to use `node:25-bookworm`
 - Updated package.json engines to require Node.js >=25.0.0
+- Upgraded Turborepo to v2 and aligned pnpm 11 across local development, CI, and the Dev Container
+- Hardened repository boundaries, CI permissions, action pinning, dependency updates, and cross-platform workflow validation
 
 ### Added
 
@@ -29,6 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Webhook delivery system
 - WebSocket system
 - Security governance documentation and baseline security middleware (Helmet.js, CORS)
+- Backend-only JWT authentication with secure cookie forwarding through the frontend gateway
+- Deterministic E2E persona seeding, including admin, user, guest, and moderator roles
+- BDD governance enforcement, implementation audits, and complete base-repository scenario coverage
+- Prometheus, Grafana, Jaeger, Loki, Promtail, and Alertmanager observability infrastructure
+- OpenTelemetry tracing, structured trace/log correlation, dashboards, alerts, and observability network policies
+- Automated Changesets version pull requests for workspace package versioning and changelogs
+
+### Fixed
+
+- Stabilized frontend linting, backend E2E infrastructure, and generated Prisma behavior in CI
+- Corrected Docker, Prisma, application, and workflow configuration for reusable forks
 
 ## [1.0.0] - 2025-11-20
 
@@ -38,5 +51,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Production-ready base repository for rapid application development
 - Complete development, testing, and deployment infrastructure
 
-[unreleased]: https://github.com/your-org/next-node-app-base/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/your-org/next-node-app-base/releases/tag/v1.0.0
+[unreleased]: https://github.com/apkasten906/next-node-app-base/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/apkasten906/next-node-app-base/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,9 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 4. **Add tests** for your changes
 5. **Ensure all tests pass** (`pnpm test`)
 6. **Update documentation** if needed
-7. **Commit your changes** using conventional commits
-8. **Push to your fork** and submit a pull request
+7. **Add a changeset** with `pnpm changeset` when changing a workspace package's public behavior
+8. **Commit your changes** using conventional commits
+9. **Push to your fork** and submit a pull request
 
 ### GitHub Actions: SHA-Pinned Actions
 
@@ -79,7 +80,7 @@ Review guidance for CI/workflow changes: `docs/Planning/WORKFLOW_CHANGE_REVIEW_P
 Our CI workflows are expected to match the repository toolchain declared in the root `package.json`:
 
 - Node: follow `engines.node` (currently `>=25.0.0`)
-- pnpm: follow `packageManager` version (currently `pnpm@11.1.3`; the actual field in `package.json` also includes a corepack-generated SHA-512 integrity hash)
+- pnpm: follow the exact `packageManager` version in the root `package.json` (currently `pnpm@11.8.0`)
 
 When updating `.github/workflows/*.yml`, keep these in sync to avoid “works locally, fails in CI” drift.
 
@@ -289,7 +290,7 @@ By contributing, you agree that your contributions will be licensed under the MI
 
 Feel free to reach out:
 
-- Create a [GitHub Discussion](https://github.com/your-org/next-node-app-base/discussions)
+- Create a [GitHub Discussion](https://github.com/apkasten906/next-node-app-base/discussions)
 - Email us at <contribute@example.com>
 - Join our Slack workspace (TBD)
 

--- a/E2E_IMPLEMENTATION_SUMMARY.md
+++ b/E2E_IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,7 @@
 # E2E Testing Implementation Summary
 
+> Historical implementation snapshot. Counts and planned scenarios below describe the initial E2E rollout and are not the current coverage source of truth. See [PROGRESS.md](PROGRESS.md) and [apps/frontend/docs/E2E_TESTING.md](apps/frontend/docs/E2E_TESTING.md) for maintained status and guidance.
+
 ## Completion Status: ✅ COMPLETE
 
 Implementation of comprehensive E2E testing infrastructure using Playwright following the plan's Enhanced CI/CD (WSJF 4.38) priority.

--- a/E2E_TESTING_STATUS.md
+++ b/E2E_TESTING_STATUS.md
@@ -1,5 +1,7 @@
 # E2E Testing Status Report
 
+> Historical snapshot from February 2026. For current commands and coverage status, see [README.md](README.md), [PROGRESS.md](PROGRESS.md), and [apps/frontend/docs/E2E_TESTING.md](apps/frontend/docs/E2E_TESTING.md).
+
 ## Summary
 
 Playwright E2E testing is configured to run end-to-end against both apps, with automatic startup via Playwright `webServer`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -158,7 +158,7 @@ The backend core is implemented and running.
 
 ### Up Next
 
-- [x] Automated semantic versioning (Changesets) — added `@changesets/cli`, version-only package scripts/config, an immutable-action-pinned Version Packages PR workflow, publishing guidance, and current 2026 `CHANGELOG.md` entries
+- [x] Review-driven semantic versioning (Changesets) — added `@changesets/cli`, version-only package scripts/config, a manually triggered and immutable-action-pinned Version Packages PR workflow, publishing guidance, and current 2026 `CHANGELOG.md` entries
 - [ ] Contract package extraction — promote stable DTOs into `@repo/contracts` once `fasciculum-instrumentorum` fork proves reuse
 - [ ] Phase 11 Feature Management System — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks; begin with ADR and interface contracts
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -104,6 +104,15 @@ The backend core is implemented and running.
 - ✅ Orphaned `node_modules/turbo-windows-64` directory removed (was causing ghost v1.13.4 resolution)
 - ✅ ADR-003 and `CONTRIBUTING.md` updated with corepack hash discipline
 
+### ✅ Chore: E2E Moderator Persona
+
+**Completed:** PR [#64](https://github.com/apkasten906/next-node-app-base/pull/64) merged to master (July 31, 2026; merge commit `cda412f`)
+
+- ✅ Added deterministic `moderator` fixtures and `MODERATOR` seed/login support across backend and frontend
+- ✅ Added backend and frontend unit coverage for defaults, validation, normalization, and seed payloads
+- ✅ Added `@ready @impl_e2e_moderator_persona` BDD contract coverage for seed upserts, fixture parity, and fallback authentication
+- ✅ Passed ADR, BDD governance, lint, backend, and cross-platform E2E CI checks
+
 ## Current Focus / Next Steps
 
 ### Current Objective: BDD Base-Repo Scenario Coverage Complete
@@ -149,7 +158,7 @@ The backend core is implemented and running.
 
 ### Up Next
 
-- [ ] E2E personas moderator (`chore/e2e-personas-moderator`) — implementation, unit coverage, and `@ready` BDD contract coverage are complete in draft PR [#64](https://github.com/apkasten906/next-node-app-base/pull/64). All required CI checks are green; the PR now awaits review and merge.
+- [x] Automated semantic versioning (Changesets) — added `@changesets/cli`, version-only package scripts/config, an immutable-action-pinned Version Packages PR workflow, publishing guidance, and current 2026 `CHANGELOG.md` entries
 - [ ] Contract package extraction — promote stable DTOs into `@repo/contracts` once `fasciculum-instrumentorum` fork proves reuse
 - [ ] Phase 11 Feature Management System — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks; begin with ADR and interface contracts
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -117,7 +117,7 @@ The backend core is implemented and running.
 
 ### Current Objective: BDD Base-Repo Scenario Coverage Complete
 
-**Goal:** Promote all base-repo scenarios to `@ready`. Adopter scenarios remain `@wip @adopter` permanently — they are implementation guides for teams forking the template, not coverage obligations here. See [plan prompt](/.github/prompts/plan-nextNodeAppBase.prompt.md) section N for the full base-vs-adopter scope tables.
+**Goal:** Promote all base-repo scenarios to `@ready`. Adopter scenarios remain `@wip @adopter` permanently — they are implementation guides for teams forking the template, not coverage obligations here. See [plan prompt](.github/prompts/plan-nextNodeAppBase.prompt.md) section N for the full base-vs-adopter scope tables.
 
 **Current tracked status (July 31, 2026):** backend 140/266 ready; frontend 31/121 ready; overall 171/387 ready. Frontend/security adopter-only scenarios are explicitly classified with `@adopter`. The new backend-ready scenario covers the deterministic moderator E2E persona contract.
 

--- a/README.md
+++ b/README.md
@@ -1,290 +1,152 @@
 # Next.js + Node.js Monorepo Base Template
 
+A production-oriented starter repository for a Next.js frontend and an Express backend, managed as a pnpm workspace with Turborepo.
+
+## Included
+
+- Next.js App Router frontend with TypeScript, Tailwind CSS, TanStack Query, and internationalization
+- Express backend with Prisma/PostgreSQL, Redis integration, JWT authentication, RBAC/ABAC, and Swagger
+- Shared workspace packages for types, configuration, constants, and utilities
+- Vitest, Playwright, and Cucumber BDD testing and governance
+- Docker Compose, Kubernetes examples, and a Prometheus/Grafana/Jaeger/Loki observability stack
+- Changesets package versioning with a reviewable Version Packages pull request
+- Security, ADR, workflow-linting, and dependency-governance foundations
+
+Adopter-specific scenarios remain tagged @wip @adopter as implementation guides. See [PROGRESS.md](PROGRESS.md) for current scope and priorities.
+
+## Prerequisites
+
+- Node.js 25 or newer
+- pnpm 11, using the version declared by packageManager in [package.json](package.json)
+- Docker with Docker Compose
+
+Corepack is the recommended way to activate the repository's pnpm version:
+
 ```bash
-# Seed the database
-pnpm prisma db seed
-
-# Start the development servers
-cd ../..
-pnpm dev
+corepack enable
+corepack install
 ```
-
-- Monorepo: Turborepo with pnpm workspaces
-- Frontend: Next.js (App Router) + TypeScript + Tailwind CSS
-- Backend: Express + TypeScript + Prisma
-- Docker: Docker Compose + multi-stage Dockerfiles
-- BDD: Cucumber features + status/implementation governance tooling + dashboard
-- Tests: Vitest (backend + frontend unit) and Playwright (E2E)
-- Observability: Correlation IDs for request tracing (`X-Correlation-ID`)
-
-## Scaffolded / Planned
-
-- Contract tests (Pact)
-- Security testing (OWASP ZAP)
-- Load testing (k6)
-- Additional deployment/observability building blocks (Kubernetes/Istio manifests and docs)
 
 ## Quick Start
 
-### Prerequisites
-
-- Node.js 25+ (for native TypeScript support - see [ADR-001](docs/adr/001-node-js-25-native-typescript.md))
-- pnpm 8+
-- Docker & Docker Compose
-- VSCode (recommended for Dev Containers)
-
-### Option 1: Dev Container (Recommended)
-
-1. Install [VSCode](https://code.visualstudio.com/) and [Docker](https://www.docker.com/)
-2. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-3. Clone the repository
-4. Open in VSCode and click "Reopen in Container"
-5. Wait for the container to build and dependencies to install
-6. Start developing
-
-### Option 2: Local Setup
-
 ```bash
-# Clone the repository
-git clone <repository-url>
+git clone https://github.com/apkasten906/next-node-app-base.git
 cd next-node-app-base
-
-# Install dependencies
 pnpm install
 
-## Set up environment variables
+cp .env.docker.example .env
+cp apps/backend/.env.example apps/backend/.env
+cp apps/frontend/.env.local.example apps/frontend/.env.local
+```
 
-This repo uses separate env files depending on how you run it:
+Start the full Docker Compose environment:
 
-- Docker Compose env (used by `docker compose`): copy `.env.docker.example` → `.env`
-- Backend local dev env (loaded from `apps/backend/.env`): copy `apps/backend/.env.example` → `apps/backend/.env`
-- Frontend local dev env (loaded by Next.js): copy `apps/frontend/.env.local.example` → `apps/frontend/.env.local`
+```bash
+docker compose up --build
+```
 
-Monorepo note: prefer scoping commands to an app/package when working with env vars (e.g. `pnpm --filter backend dev`, `pnpm --filter frontend dev`, `pnpm --filter frontend test:e2e`).
+Or run the applications locally while PostgreSQL and Redis run in Docker:
 
-# Start development services (PostgreSQL, Redis, etc.)
-docker compose up -d
-
-# Run database migrations
-cd apps/backend
-pnpm prisma migrate dev
-
-# Seed the database
-pnpm prisma db seed
-
-# Start the development servers
-cd ../..
+```bash
+docker compose up -d postgres redis
+pnpm db:migrate
+pnpm db:seed
 pnpm dev
 ```
 
-Note: By default, Postgres/Redis are not published to localhost ports (to avoid conflicts with existing local services). See `docs/DOCKER.md` for how to expose ports via an override file if you need host access.
+- Frontend: <http://localhost:3000>
+- Backend health: <http://localhost:3001/health>
+- API documentation: <http://localhost:3001/api-docs>
 
-## Project Structure
+PostgreSQL and Redis are internal-only by default. See [Docker documentation](docs/DOCKER.md) for host-port overrides. For a Dev Container setup, open the repository in VS Code with the Dev Containers extension and select **Reopen in Container**.
 
-````text
+## Common Commands
+
+```bash
+pnpm dev
+pnpm build
+pnpm lint
+pnpm format:check
+pnpm typecheck
+pnpm test
+pnpm test:unit
+pnpm test:integration
+pnpm test:e2e
+pnpm test:bdd
+pnpm bdd:status
+pnpm db:migrate
+pnpm db:seed
+pnpm db:studio
+pnpm changeset
+pnpm changeset:status
+```
+
+Install Playwright browsers before the first E2E run:
+
+```bash
+pnpm --filter frontend exec playwright install
+```
+
+## Workspace Layout
+
+```text
 next-node-app-base/
-├── .devcontainer/          # Dev Container configuration
-```bash
-# Development
-pnpm dev                    # Start all apps in development mode
-pnpm dev:frontend           # Start only frontend
-pnpm dev:backend            # Start only backend
-
-# Building
-pnpm build                  # Build all apps
-pnpm build:frontend         # Build frontend
-pnpm build:backend          # Build backend
-
-# Testing
-
-## First-Time Setup
-
-Install Playwright browsers (required for E2E tests):
-
-```bash
-# Windows
-.\scripts\setup-playwright.ps1
-
-# Linux/Mac
-./scripts/setup-playwright.sh
-
-# Or manually
-pnpm playwright install
-````
-
-## Building
-
-pnpm build # Build all apps
-pnpm build:frontend # Build frontend
-pnpm build:backend # Build backend
-
-## Testing
-
-### First-Time Setup
-
-Install Playwright browsers (required for E2E tests):
-
-```bash
-# Windows
-.\scripts\setup-playwright.ps1
-
-# Linux/Mac
-./scripts/setup-playwright.sh
-
-# Or manually
-pnpm playwright install
+|-- apps/
+|   |-- backend/
+|   +-- frontend/
+|-- packages/
+|   |-- config/
+|   |-- constants/
+|   |-- types/
+|   +-- utils/
+|-- docs/
+|-- kubernetes/
+|-- scripts/
++-- .github/
 ```
 
-### Running Tests
+Applications consume shared packages through pnpm's workspace protocol. Workspace packages are currently private, which prevents accidental registry publication; this does not affect using the repository as a public GitHub template.
 
-**Important for E2E tests:** Playwright automatically starts both frontend and backend servers before running tests. No manual server startup required!
+## Testing and BDD
 
-```bash
-pnpm test                   # Run all tests
-pnpm test:unit              # Run unit tests
-pnpm test:integration       # Run integration tests
-pnpm test:e2e               # Run E2E tests (automatically starts servers)
-pnpm test:e2e:ui            # Run E2E tests in interactive UI mode
-pnpm test:e2e:debug         # Run E2E tests in debug mode
-pnpm test:contract          # Run contract tests
-pnpm test:security          # Run security tests
-pnpm test:load              # Run load tests (requires k6 + scenarios; scaffolded)
-```
+Playwright starts the frontend and backend automatically for E2E runs and uses deterministic seed personas. CI exercises Chromium, Firefox, and WebKit on Linux, plus selected Windows and macOS projects.
 
-**E2E Test Details:**
+BDD status:
 
-- Runs across multiple browser projects (Chromium, Firefox, WebKit, mobile emulation)
-- Servers auto-start: Backend (port 3001) + Frontend (port 3000)
-- Tests wait for servers to be ready before executing
-- Servers auto-shutdown after tests complete
+- @ready: implemented base-repository behavior in the default BDD gate
+- @wip @adopter: guidance for applications created from this template
+- @manual: behavior requiring manual verification
 
-**E2E / Playwright env vars (optional):**
+See [BDD documentation](docs/BDD.md), [testing documentation](docs/TESTING.md), and the [E2E guide](apps/frontend/docs/E2E_TESTING.md).
 
-- `E2E_SEED_TOKEN`: token sent as `x-e2e-seed-token` to `POST /api/e2e/seed` (default: `local-e2e-seed-token`)
-- `E2E_BACKEND_URL`: override backend base URL for E2E setup (default: `http://localhost:3001`)
-- `E2E_BASE_URL`: override frontend base URL for E2E setup (default: `http://localhost:3000`)
-- `REUSE_EXISTING_SERVER`: controls Playwright `webServer.reuseExistingServer` (`true`/`false`); by default it reuses locally and does not reuse in CI unless explicitly set
+## Versioning and Publishing
 
-See [TEST_EXPLORER_GUIDE.md](docs/TEST_EXPLORER_GUIDE.md) for VSCode Test Explorer setup.
+Changesets manages package versions independently:
 
-### Code Quality
+1. Run pnpm changeset in a pull request that changes a workspace package's public behavior.
+2. After that changeset reaches master, the Version Packages workflow opens or updates a release PR.
+3. Merge the release PR to update package versions and changelogs.
+4. Publish explicitly through the Publish Packages workflow after the intended package is marked publishable.
 
-```bash
-pnpm lint # Lint all code
-pnpm lint:fix # Fix linting issues
-pnpm lint:workflows # Lint GitHub Actions workflows (actionlint)
-pnpm format # Format code with Prettier
-pnpm typecheck # Run TypeScript type checking
-```
-
-### Database
-
-```bash
-pnpm db:migrate # Run database migrations
-pnpm db:seed # Seed database
-pnpm db:studio # Open Prisma Studio
-pnpm db:reset # Reset database#
-```
-
-### Git hooks
-
-This repository uses Husky hooks to enforce linting, commit message rules, and a fast test gate before pushing.
-
-- `pre-commit`: runs `lint-staged` (Prettier + ESLint) and a quick TypeScript check on `apps/backend`.
-- `commit-msg`: runs `commitlint` to enforce conventional commit messages.
-- `pre-push`: runs a quick mocked backend test run via `scripts/run-backend-tests-ci.js` which sets `TEST_EXTERNAL_SERVICES=false` and `REDIS_MOCK=true`.
-
-If a hook fails, fix the issues locally and re-run the commands. CI runs the same checks and will block merges if they fail.
-
-## Security
-
-This project follows OWASP security standards and best practices:
-
-- **Governance**: OWASP-oriented security governance docs and standards
-- **Security Headers**: Helmet.js baseline middleware
-- **Authorization**: RBAC/ABAC services and middleware
-- **Encryption**: Encryption/hashing services for secrets and credentials
-- Planned/scaffolded: Istio mTLS integration, dependency scanning, OWASP ZAP DAST
-
-See [SECURITY.md](SECURITY.md) for vulnerability reporting.
+Repository/template releases are separate Git tags and GitHub releases. Repository-only documentation, CI, and tooling changes do not require artificial package changesets. See [Publishing Packages](docs/PUBLISHING.md).
 
 ## Documentation
 
-Docs live in `docs/` (plus some app-specific docs under `apps/*/docs/`). Start here:
-
-- `docs/BDD.md`
-- `docs/BDD_IMPLEMENTATION_AUDIT.md`
-- `docs/CORRELATION_ID.md`
-- `docs/DOCKER.md`
-- `docs/TESTING.md`
-- `docs/TEST_EXPLORER_GUIDE.md`
-- `docs/WEBSOCKET.md`
-- `docs/security-governance.md`
-- ADRs: `docs/adr/`
-
-## Internationalization
-
-The application supports multiple languages:
-
-- English (en) - Default
-- Spanish (es)
-- French (fr)
-- German (de)
-
-Translations live under `apps/frontend/public/locales/` and i18n configuration is in `apps/frontend/i18n.ts`.
-
-## Deployment
-
-### Deployment Strategies
-
-Kubernetes/Istio deployment content is included as scaffolding and examples (for example, see the Verdaccio manifests).
-
-- **Blue-Green**: Zero-downtime deployments with instant rollback
-- **Canary**: Gradual traffic shifting (5% → 25% → 50% → 100%)
-- **A/B Testing**: User segment-based routing
-
-See:
-
-- `docs/DOCKER.md` for local Docker workflows
-- `kubernetes/verdaccio/README.md` for a Kubernetes + Istio example
-
-### Environments
-
-- **Development**: Local development with Docker Compose
-- **Staging**: Kubernetes cluster with Istio (pre-production)
-- **Production**: Kubernetes cluster with Istio (high availability)
+- [Setup](SETUP.md)
+- [Security policy](SECURITY.md)
+- [Security governance](docs/security-governance.md)
+- [Architecture Decision Records](docs/adr/README.md)
+- [Authorization](docs/ABAC_GUIDE.md)
+- [Docker](docs/DOCKER.md)
+- [File storage](docs/FILE_STORAGE.md)
+- [Notifications](docs/NOTIFICATION_SERVICE.md)
+- [Queues](docs/QUEUE_SYSTEM.md)
+- [WebSockets](docs/WEBSOCKET.md)
 
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on:
-
-- Code of Conduct
-- Development workflow
-- Pull request process
-- Coding standards
-- Commit message conventions
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development standards and the pull-request process. File bugs and feature requests in [GitHub Issues](https://github.com/apkasten906/next-node-app-base/issues).
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Acknowledgments
-
-Built with amazing open-source technologies:
-
-- [Next.js](https://nextjs.org/)
-- [Express](https://expressjs.com/)
-- [Prisma](https://www.prisma.io/)
-- [Turborepo](https://turbo.build/)
-- [Istio](https://istio.io/)
-- [Kubernetes](https://kubernetes.io/)
-- And many more...
-
-## Support
-
-- 📧 Email: [support@example.com](mailto:support@example.com)
-- 🐛 Issues: [GitHub Issues](https://github.com/your-org/next-node-app-base/issues)
-
----
-
-**⭐ If this template helps you, please give it a star!**
+This project is licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The [BDD implementer coverage reference](docs/BDD.md#implementer-coverage-refere
 Changesets manages package versions independently:
 
 1. Run pnpm changeset in a pull request that changes a workspace package's public behavior.
-2. After that changeset reaches master, the Version Packages workflow opens or updates a release PR.
+2. When preparing a release, manually run the Version Packages workflow to open or update the release PR from changesets accumulated on master.
 3. Merge the release PR to update package versions and changelogs.
 4. Publish explicitly through the Publish Packages workflow after the intended package is marked publishable.
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ BDD status:
 - @wip @adopter: guidance for applications created from this template
 - @manual: behavior requiring manual verification
 
-See [BDD documentation](docs/BDD.md), [testing documentation](docs/TESTING.md), and the [E2E guide](apps/frontend/docs/E2E_TESTING.md).
+The [BDD implementer coverage reference](docs/BDD.md#implementer-coverage-reference) explains how to browse every scenario and isolate the `@wip @adopter` implementation backlog in the admin-only BDD dashboard. See also the [testing documentation](docs/TESTING.md) and [E2E guide](apps/frontend/docs/E2E_TESTING.md).
 
 ## Versioning and Publishing
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -5,7 +5,7 @@ This repo is a working Next.js + Node.js monorepo (frontend + backend), with Doc
 ## Prerequisites
 
 - Node.js 25+
-- pnpm 8+
+- pnpm 11, using the version declared in the root package.json
 - Docker + Docker Compose
 
 ## Option A: Docker Compose (fastest)
@@ -41,11 +41,7 @@ docker compose up -d postgres redis
 - Copy `apps/backend/.env.example` to `apps/backend/.env` (or export env vars another way).
 - Copy `apps/frontend/.env.local.example` to `apps/frontend/.env.local` and ensure it contains at least:
 
-```env
-NEXT_PUBLIC_API_URL=http://localhost:3001
-NEXTAUTH_URL=http://localhost:3000
-NEXTAUTH_SECRET=dev-nextauth-secret-change-in-production
-```
+Use the documented defaults in the example files and replace all production secrets before deployment.
 
 4. Run migrations and start dev:
 
@@ -69,7 +65,7 @@ pnpm typecheck
 ## Frontend build verification
 
 - Build command: `pnpm -w -C apps/frontend run build`
- - Status: Verified locally (originally on branch `chore/ci-dry-workflows`, merged in PR #29) — the Next.js production build completes successfully.
+- Status: The Next.js production build is enforced by CI.
 - Windows caveat: On Windows the build may require Developer Mode to allow creation of filesystem symlinks. If Developer Mode is not enabled you can see `EPERM` errors during linking. Some setups may also emit a "IO error: provided value is too long when setting link name" warning for certain symlinked files; the build artifacts are still produced. Workarounds:
   - Enable Windows Developer Mode (recommended for native Windows development).
   - Use WSL2 or a Linux/macOS CI runner to avoid Windows symlink/long-path issues.

--- a/docs/BDD.md
+++ b/docs/BDD.md
@@ -116,6 +116,36 @@ Notes:
 - You may use a feature-level status tag (e.g. `@wip` above `Feature:`) as a default.
 - If a scenario has its own status tag, it overrides the feature-level status for governance reporting.
 
+## Implementer Coverage Reference
+
+The Gherkin files are the comprehensive, version-controlled list of behaviors available to teams adopting this template:
+
+- `apps/backend/features/*.feature`
+- `apps/frontend/features/*.feature`
+
+Use the scenario tags to distinguish responsibility:
+
+- `@ready` describes base-template behavior that is already implemented and enforced.
+- `@wip @adopter` describes product-, provider-, operations-, or UX-specific behavior that an adopting team may implement.
+- `@manual` describes behavior that requires documented manual verification.
+
+The BDD Governance dashboard presents the same source data as an implementer-friendly catalog. With the backend and frontend running, sign in as an administrator and open:
+
+- <http://localhost:3000/dashboard/bdd> for every feature and scenario
+- <http://localhost:3000/dashboard/bdd?states=wip> for the implementation backlog
+
+The dashboard shows each scenario's feature file, effective status, `@impl_*` traceability tag, and other tags. In the WIP view, use the displayed `@adopter` tag to identify intended adopter work; a WIP scenario without `@adopter` is ordinary unfinished repository work and should not automatically become an adopter requirement.
+
+For a non-UI view:
+
+```bash
+pnpm bdd:status
+node scripts/bdd-status.js --format json
+node scripts/bdd-impl-audit.js --format markdown
+```
+
+The dashboard and CLI reports are generated from the feature files. Do not maintain a separate copied scenario checklist, because it would drift from the executable specifications.
+
 ## Running Cucumber Tests
 
 ### Backend

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -374,7 +374,7 @@ USER nodejs
 ### 2. Minimal Base Images
 
 - Using Alpine Linux (5MB base)
-- Node.js 20 Alpine images
+- Node.js 25 Alpine images
 - No unnecessary packages
 
 ### 3. Multi-Stage Builds

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -266,11 +266,11 @@ pnpm changeset
 
 Select the affected workspace packages, choose the semantic version bump, and describe the user-visible change. Pull requests that only change documentation, tests, CI, or repository maintenance do not need a changeset.
 
-### Automated Version Pull Requests
+### Manually Triggered Version Pull Requests
 
-On every push to `master`, `.github/workflows/version-packages.yml` uses the committed changeset files to open or update a `chore(release): version packages` pull request. That pull request updates package versions and package-level changelogs independently.
+When a release is ready to prepare, manually run `.github/workflows/version-packages.yml` from the GitHub Actions tab. It uses the changeset files accumulated on `master` to open or update a `chore(release): version packages` pull request. That pull request updates package versions and package-level changelogs independently.
 
-The workflow versions private packages so the repository can prepare `@repo/types` and future packages such as `@repo/contracts` before they become publishable. It does not publish packages or create tags. Publishing remains an explicit operation through the existing Publish Packages workflow after a package is marked `"private": false` and reviewed.
+The workflow does not run on ordinary pushes. It versions private packages so the repository can prepare `@repo/types` and future packages such as `@repo/contracts` before they become publishable. It does not publish packages or create tags. Publishing remains an explicit operation through the existing Publish Packages workflow after a package is marked `"private": false` and reviewed.
 
 ## Service Mesh Integration
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -420,7 +420,7 @@ turbo run build --filter=@apkasten906/types
 ## Future Enhancements
 
 - [x] **GitHub Actions workflow for automated publishing** - IMPLEMENTED (`.github/workflows/publish.yml`)
-- [ ] Automated versioning with changesets or semantic-release
+- [x] **Changesets versioning** - Version Packages PR automation is implemented
 - [ ] Provenance attestation for published packages
 - [ ] NPM package signing
 - [ ] Pre-publish validation hooks

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -258,19 +258,19 @@ Set `"private": true` in `package.json`. The publish script automatically skips 
 
 ## Versioning
 
-### Manual Version Bumps
+### Add a Changeset
 
 ```bash
-# In the package directory
-cd packages/types
-pnpm version patch  # 1.0.0 → 1.0.1
-pnpm version minor  # 1.0.0 → 1.1.0
-pnpm version major  # 1.0.0 → 2.0.0
+pnpm changeset
 ```
 
-### Automated Versioning (TODO)
+Select the affected workspace packages, choose the semantic version bump, and describe the user-visible change. Pull requests that only change documentation, tests, CI, or repository maintenance do not need a changeset.
 
-Future enhancement: Integrate [changesets](https://github.com/changesets/changesets) or [semantic-release](https://github.com/semantic-release/semantic-release) for automated versioning based on conventional commits.
+### Automated Version Pull Requests
+
+On every push to `master`, `.github/workflows/version-packages.yml` uses the committed changeset files to open or update a `chore(release): version packages` pull request. That pull request updates package versions and package-level changelogs independently.
+
+The workflow versions private packages so the repository can prepare `@repo/types` and future packages such as `@repo/contracts` before they become publishable. It does not publish packages or create tags. Publishing remains an explicit operation through the existing Publish Packages workflow after a package is marked `"private": false` and reviewed.
 
 ## Service Mesh Integration
 

--- a/docs/adr/001-node-js-25-native-typescript.md
+++ b/docs/adr/001-node-js-25-native-typescript.md
@@ -190,7 +190,7 @@ This decision will be reviewed after:
 - [Node.js 25 Release Notes](https://nodejs.org/en/blog/release/v25.0.0)
 - [Node.js TypeScript Support Documentation](https://nodejs.org/docs/latest/api/typescript.html)
 - [Project Setup Documentation](../../SETUP.md)
-- [Development Environment](.devcontainer/devcontainer.json)
+- [Development Environment](../../.devcontainer/devcontainer.json)
 
 ## References
 

--- a/docs/adr/005-owasp-security-standards.md
+++ b/docs/adr/005-owasp-security-standards.md
@@ -360,7 +360,7 @@ OWASP compliance helps with:
 
 - [ADR-007: Passport.js Authentication Abstraction](007-passport-js-authentication.md)
 - [SECURITY.md](../../SECURITY.md)
-- [Security Architecture](../architecture/security-architecture.md) (planned)
+- [Security Governance](../security-governance.md)
 
 ## References
 

--- a/package.json
+++ b/package.json
@@ -49,10 +49,14 @@
     "prisma:upgrade": "cd apps/backend && pnpm add -D prisma@7.1.0 && pnpm add @prisma/client@7.1.0 @prisma/adapter-pg@7.1.0",
     "prepare": "node -e \"if (process.env.HUSKY === '0' || process.env.CI) process.exit(0); require('child_process').execSync('husky install', { stdio: 'inherit' });\"",
     "ci:backend-tests": "node ./scripts/run-backend-tests-ci.js",
+    "changeset": "changeset",
+    "changeset:status": "changeset status",
+    "version:packages": "changeset version",
     "publish:packages": "node ./scripts/publish-packages.js",
     "publish:dry-run": "DRY_RUN=true node ./scripts/publish-packages.js"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.31.1",
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^18.4.3",
     "@prisma/config": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
         specifier: ^4.1.13
         version: 4.4.3
     devDependencies:
+      '@changesets/cli':
+        specifier: ^2.31.1
+        version: 2.31.1(@types/node@24.12.4)
       '@commitlint/cli':
         specifier: ^18.4.3
         version: 18.6.1(@types/node@24.12.4)(typescript@5.9.3)
@@ -215,7 +218,7 @@ importers:
         version: 6.2.8(openapi-types@12.1.3)
       swagger-ui-express:
         specifier: ^5.0.1
-        version: 5.0.1(express@5.2.1(supports-color@8.1.1))
+        version: 5.0.1(express@5.2.1)
       tsyringe:
         specifier: ^4.10.0
         version: 4.10.0
@@ -720,6 +723,61 @@ packages:
   '@bull-board/ui@6.21.3':
     resolution: {integrity: sha512-s/PLBJab8cnoQAGVqjQb0v4oGe0KgB4aQ5G5g93doxzXB/D+wkXNL9P9+zLWLldBJXE57jL4CR99ttDCIiyNHw==}
 
+  '@changesets/apply-release-plan@7.1.1':
+    resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
+
+  '@changesets/assemble-release-plan@6.0.10':
+    resolution: {integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==}
+
+  '@changesets/changelog-git@0.2.1':
+    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+
+  '@changesets/cli@2.31.1':
+    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
+    hasBin: true
+
+  '@changesets/config@3.1.4':
+    resolution: {integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==}
+
+  '@changesets/errors@0.2.0':
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+
+  '@changesets/get-dependents-graph@2.1.4':
+    resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
+
+  '@changesets/get-release-plan@4.0.16':
+    resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
+
+  '@changesets/get-version-range-type@0.4.0':
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+
+  '@changesets/git@3.0.4':
+    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
+
+  '@changesets/logger@0.1.1':
+    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+
+  '@changesets/parse@0.4.3':
+    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
+
+  '@changesets/pre@2.0.2':
+    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
+
+  '@changesets/read@0.6.7':
+    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
+
+  '@changesets/should-skip-package@0.1.2':
+    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
+
+  '@changesets/types@4.1.0':
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+
+  '@changesets/types@6.1.0':
+    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
+
+  '@changesets/write@0.4.0':
+    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -1137,6 +1195,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
@@ -1175,6 +1242,12 @@ packages:
 
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
+  '@manypkg/find-root@1.1.0':
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+
+  '@manypkg/get-packages@1.1.3':
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -2355,6 +2428,9 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
@@ -2716,6 +2792,10 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -2753,6 +2833,9 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2770,6 +2853,10 @@ packages:
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
 
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
@@ -2886,6 +2973,10 @@ packages:
     resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}
     engines: {node: '>= 18'}
 
+  better-path-resolve@1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
+
   better-result@2.9.2:
     resolution: {integrity: sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==}
 
@@ -3001,6 +3092,9 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
@@ -3295,6 +3389,10 @@ packages:
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -3305,6 +3403,10 @@ packages:
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -3389,6 +3491,10 @@ packages:
   enhanced-resolve@5.21.5:
     resolution: {integrity: sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==}
     engines: {node: '>=10.13.0'}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
 
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
@@ -3568,6 +3674,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -3623,6 +3734,9 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extendable-error@0.1.7:
+    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
@@ -3755,6 +3869,14 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -3891,6 +4013,10 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
     engines: {node: '>=14'}
@@ -4014,6 +4140,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  human-id@4.2.0:
+    resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
+    hasBin: true
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -4225,6 +4355,10 @@ packages:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
 
+  is-subdir@1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+
   is-symbol@1.1.1:
     resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
     engines: {node: '>= 0.4'}
@@ -4248,6 +4382,10 @@ packages:
   is-weakset@2.0.4:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
+
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -4294,6 +4432,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -4329,6 +4471,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -4714,6 +4859,10 @@ packages:
     resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
     engines: {node: '>= 0.8.0'}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -4991,9 +5140,16 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  outdent@0.5.0:
+    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  p-filter@2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -5011,12 +5167,19 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-map@2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
+
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
   pad-right@0.2.2:
     resolution: {integrity: sha512-4cy8M95ioIGolCoMmm2cMntGR1lPLEbOMzOKu8bzjuJP6JpzEMQcDHmh7hHLYGgob+nKe1YHFMaG4V59HQa89g==}
@@ -5154,6 +5317,10 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
@@ -5231,6 +5398,11 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
@@ -5291,6 +5463,9 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5353,6 +5528,10 @@ packages:
   read-pkg@5.2.0:
     resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
     engines: {node: '>=8'}
+
+  read-yaml-file@1.1.0:
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -5599,6 +5778,10 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -5639,6 +5822,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  spawndamnit@3.0.1:
+    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -5657,6 +5843,9 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
@@ -5849,6 +6038,10 @@ packages:
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
     engines: {node: '>=14'}
+
+  term-size@2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
 
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
@@ -6047,6 +6240,10 @@ packages:
   unicorn-magic@0.4.0:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
     engines: {node: '>=20'}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -6917,6 +7114,149 @@ snapshots:
     dependencies:
       '@bull-board/api': 6.21.3(@bull-board/ui@6.21.3)
 
+  '@changesets/apply-release-plan@7.1.1':
+    dependencies:
+      '@changesets/config': 3.1.4
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      detect-indent: 6.1.0
+      fs-extra: 7.0.1
+      lodash.startcase: 4.4.0
+      outdent: 0.5.0
+      prettier: 2.8.8
+      resolve-from: 5.0.0
+      semver: 7.8.0
+
+  '@changesets/assemble-release-plan@6.0.10':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      semver: 7.8.0
+
+  '@changesets/changelog-git@0.2.1':
+    dependencies:
+      '@changesets/types': 6.1.0
+
+  '@changesets/cli@2.31.1(@types/node@24.12.4)':
+    dependencies:
+      '@changesets/apply-release-plan': 7.1.1
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/changelog-git': 0.2.1
+      '@changesets/config': 3.1.4
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/get-release-plan': 4.0.16
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@changesets/write': 0.4.0
+      '@inquirer/external-editor': 1.0.3(@types/node@24.12.4)
+      '@manypkg/get-packages': 1.1.3
+      ansi-colors: 4.1.3
+      enquirer: 2.4.1
+      fs-extra: 7.0.1
+      mri: 1.2.0
+      package-manager-detector: 0.2.11
+      picocolors: 1.1.1
+      resolve-from: 5.0.0
+      semver: 7.8.0
+      spawndamnit: 3.0.1
+      term-size: 2.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@changesets/config@3.1.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/logger': 0.1.1
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+      micromatch: 4.0.8
+
+  '@changesets/errors@0.2.0':
+    dependencies:
+      extendable-error: 0.1.7
+
+  '@changesets/get-dependents-graph@2.1.4':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      picocolors: 1.1.1
+      semver: 7.8.0
+
+  '@changesets/get-release-plan@4.0.16':
+    dependencies:
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/config': 3.1.4
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/get-version-range-type@0.4.0': {}
+
+  '@changesets/git@3.0.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@manypkg/get-packages': 1.1.3
+      is-subdir: 1.2.0
+      micromatch: 4.0.8
+      spawndamnit: 3.0.1
+
+  '@changesets/logger@0.1.1':
+    dependencies:
+      picocolors: 1.1.1
+
+  '@changesets/parse@0.4.3':
+    dependencies:
+      '@changesets/types': 6.1.0
+      js-yaml: 4.1.1
+
+  '@changesets/pre@2.0.2':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+
+  '@changesets/read@0.6.7':
+    dependencies:
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/parse': 0.4.3
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      p-filter: 2.1.0
+      picocolors: 1.1.1
+
+  '@changesets/should-skip-package@0.1.2':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/types@4.1.0': {}
+
+  '@changesets/types@6.1.0': {}
+
+  '@changesets/write@0.4.0':
+    dependencies:
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      human-id: 4.2.0
+      prettier: 2.8.8
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -7399,6 +7739,13 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/external-editor@1.0.3(@types/node@24.12.4)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 24.12.4
+
   '@ioredis/commands@1.5.1': {}
 
   '@isaacs/cliui@8.0.2':
@@ -7441,6 +7788,22 @@ snapshots:
   '@jsdevtools/ono@7.1.3': {}
 
   '@kurkle/color@0.3.4': {}
+
+  '@manypkg/find-root@1.1.0':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+
+  '@manypkg/get-packages@1.1.3':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@changesets/types': 4.1.0
+      '@manypkg/find-root': 1.1.0
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      read-yaml-file: 1.1.0
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -8738,6 +9101,8 @@ snapshots:
     dependencies:
       '@types/node': 24.12.4
 
+  '@types/node@12.20.55': {}
+
   '@types/node@24.12.4':
     dependencies:
       undici-types: 7.16.0
@@ -9197,6 +9562,8 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-colors@4.1.3: {}
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -9221,6 +9588,10 @@ snapshots:
 
   arg@4.1.3: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
@@ -9242,6 +9613,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
+
+  array-union@2.1.0: {}
 
   array.prototype.findlast@1.2.5:
     dependencies:
@@ -9365,6 +9738,10 @@ snapshots:
     dependencies:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4
+
+  better-path-resolve@1.0.0:
+    dependencies:
+      is-windows: 1.0.2
 
   better-result@2.9.2: {}
 
@@ -9510,6 +9887,8 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  chardet@2.2.0: {}
 
   chart.js@4.5.1:
     dependencies:
@@ -9765,6 +10144,8 @@ snapshots:
 
   destr@2.0.5: {}
 
+  detect-indent@6.1.0: {}
+
   detect-libc@2.1.2: {}
 
   dezalgo@1.0.4:
@@ -9773,6 +10154,10 @@ snapshots:
       wrappy: 1.0.2
 
   diff@4.0.4: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
 
   doctrine@2.1.0:
     dependencies:
@@ -9871,6 +10256,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
 
   env-paths@3.0.0: {}
 
@@ -10276,6 +10666,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -10362,6 +10754,8 @@ snapshots:
   exsolve@1.0.8: {}
 
   extend@3.0.2: {}
+
+  extendable-error@0.1.7: {}
 
   fast-check@3.23.2:
     dependencies:
@@ -10509,6 +10903,18 @@ snapshots:
   fraction.js@5.3.4: {}
 
   fresh@2.0.0: {}
+
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
 
   fs.realpath@1.0.0: {}
 
@@ -10672,6 +11078,15 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.1
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
   google-auth-library@9.15.1:
     dependencies:
       base64-js: 1.5.1
@@ -10802,6 +11217,8 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  human-id@4.2.0: {}
 
   human-signals@2.1.0: {}
 
@@ -10996,6 +11413,10 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-subdir@1.2.0:
+    dependencies:
+      better-path-resolve: 1.0.0
+
   is-symbol@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -11020,6 +11441,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-windows@1.0.2: {}
 
   isarray@2.0.5: {}
 
@@ -11065,6 +11488,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.15.0:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -11090,6 +11518,10 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsonparse@1.3.1: {}
 
@@ -11434,6 +11866,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mri@1.2.0: {}
+
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
@@ -11611,7 +12045,7 @@ snapshots:
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.3
-      semver: 7.7.4
+      semver: 7.8.0
       validate-npm-package-license: 3.0.4
 
   notepack.io@3.0.1: {}
@@ -11728,11 +12162,17 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  outdent@0.5.0: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  p-filter@2.1.0:
+    dependencies:
+      p-map: 2.1.0
 
   p-limit@2.3.0:
     dependencies:
@@ -11750,9 +12190,15 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-map@2.1.0: {}
+
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
+
+  package-manager-detector@0.2.11:
+    dependencies:
+      quansync: 0.2.11
 
   pad-right@0.2.2:
     dependencies:
@@ -11877,6 +12323,8 @@ snapshots:
 
   pidtree@0.6.0: {}
 
+  pify@4.0.1: {}
+
   pkg-types@2.3.1:
     dependencies:
       confbox: 0.2.4
@@ -11937,6 +12385,8 @@ snapshots:
   preact@10.29.2: {}
 
   prelude-ls@1.2.1: {}
+
+  prettier@2.8.8: {}
 
   prettier@3.8.3: {}
 
@@ -12012,6 +12462,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  quansync@0.2.11: {}
+
   queue-microtask@1.2.3: {}
 
   quick-lru@4.0.1: {}
@@ -12079,6 +12531,13 @@ snapshots:
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
+
+  read-yaml-file@1.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      js-yaml: 3.15.0
+      pify: 4.0.1
+      strip-bom: 3.0.0
 
   readable-stream@3.6.2:
     dependencies:
@@ -12407,6 +12866,8 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  slash@3.0.0: {}
+
   slice-ansi@5.0.0:
     dependencies:
       ansi-styles: 6.2.3
@@ -12476,6 +12937,11 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  spawndamnit@3.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -12495,6 +12961,8 @@ snapshots:
       readable-stream: 3.6.2
 
   split2@4.2.0: {}
+
+  sprintf-js@1.0.3: {}
 
   sqlstring@2.3.3: {}
 
@@ -12687,7 +13155,7 @@ snapshots:
     dependencies:
       '@scarf/scarf': 1.4.0
 
-  swagger-ui-express@5.0.1(express@5.2.1(supports-color@8.1.1)):
+  swagger-ui-express@5.0.1(express@5.2.1):
     dependencies:
       express: 5.2.1(supports-color@8.1.1)
       swagger-ui-dist: 5.32.6
@@ -12712,6 +13180,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  term-size@2.2.1: {}
 
   test-exclude@7.0.2:
     dependencies:
@@ -12911,6 +13381,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   unicorn-magic@0.4.0: {}
+
+  universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add `@changesets/cli` and root commands for creating changesets, checking release status, and versioning workspace packages.
- Configure independent versioning for private workspace packages in `.changeset/config.json`.
- Add a Version Packages workflow that opens or updates a release PR after changesets reach `master`.
- Keep publishing separate and explicitly gated behind the existing Publish Packages workflow.
- Document the changeset and release process in `docs/PUBLISHING.md`.
- Update `CHANGELOG.md` with the repository’s 2026 work.
- Update `PROGRESS.md` and the planning prompt to mark Changesets complete and promote contract extraction as the next item.
- Record the previously merged moderator-persona work in the progress documentation.

The repository is now equipped for reviewable package versioning before any shared workspace package becomes publishable. Repository/template releases remain separate from package releases.

## Testing

- `pnpm changeset:status`
- Prettier checks on all changed files
- `pnpm lint:workflows`
- `git diff --check`
- `pnpm install --frozen-lockfile`
- Pre-push backend unit checks:
  - 3 test files passed
  - 8 tests passed
  - 38 test files and 394 non-unit tests skipped as expected

## Checklist

- [ ] CI is green
- [x] No secrets added/printed

### If this PR touches `.github/workflows/` or `.github/dependabot.yml`

- [x] Workflow/job `permissions:` are least-privilege
- [x] Actions are pinned to commit SHAs (keep the `# vX` comment)
- [x] No `:latest` Docker images (prefer pinned versions)
- [x] `Workflow Lint` check passes
- [x] CI toolchain matches root `package.json` (`engines.node`, `packageManager`)