### PR TITLE
Agent/bdd responsibility governance

### DIFF
--- a/.github/prompts/plan-nextNodeAppBase.prompt.md
+++ b/.github/prompts/plan-nextNodeAppBase.prompt.md
@@ -466,7 +466,7 @@ Consequence: lower migration risk and clearer package boundaries.
 
 - ✅ **Review-driven semantic versioning (Changesets)** — `@changesets/cli`, private-package versioning config, a manually triggered and immutable-action-pinned Version Packages PR workflow, current 2026 changelog entries, and publishing guidance are complete. Version preparation and publishing remain explicit operator actions.
 
-1. **BDD responsibility taxonomy** — introduce `@template` / `@adopter` as a responsibility dimension independent of `@ready` / `@wip` / `@manual` / `@skip`; migrate governance, dashboard, profiles, scenarios, tests, and docs atomically.
+1. ✅ **BDD responsibility taxonomy** — `@template` / `@adopter` is now a responsibility dimension independent of `@ready` / `@wip` / `@manual` / `@skip`; governance, dashboard, profiles, all 387 scenarios, tests, and docs were migrated atomically.
 2. **Template-ready milestone release** — after the responsibility taxonomy merges, manually create the repository tag and GitHub release. Do not run package versioning or publishing: all workspace packages remain private and the current distribution goal is GitHub clone/template use.
 3. **Contract package extraction** (Migration Plan step 6) — first bootstrapped fork will be `fasciculum-instrumentorum`; promote stable DTOs from `lib/contracts/` into `@repo/types` or a successor `@repo/contracts` package once that fork proves reuse.
 4. **Phase 11 Feature Management System** — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks. No code exists yet; begin with ADR and interface contracts in `packages/types`.
@@ -475,7 +475,7 @@ Consequence: lower migration risk and clearer package boundaries.
 
 The dividing line: **base repo = infrastructure, conventions, and cross-cutting concerns the template wires up for any adopter; adopter = business domain logic, provider choices, production ops, and app-specific UX.**
 
-### Agreed taxonomy (planned)
+### Implemented taxonomy
 
 Status and responsibility are independent:
 
@@ -485,7 +485,7 @@ Status and responsibility are independent:
 - Feature-level tags may provide defaults, with explicit scenario-level overrides.
 - Default CI selects template-owned ready scenarios. Dashboard reporting defaults to template scope and provides an adopter-backlog preset.
 
-Until the migration is complete, existing `@wip @adopter` scenarios retain their current meaning. The migration must update governance scripts, API/dashboard types, filters and totals, Cucumber profiles, all feature files, tests, and documentation in one change.
+The migration classifies 171 template-owned ready scenarios and 216 adopter-owned WIP scenarios. Default Cucumber profiles and dashboard reporting select template-owned behavior; the dashboard provides an adopter-backlog preset.
 
 ### Base repo responsibility (complete)
 
@@ -536,4 +536,4 @@ Until the migration is complete, existing `@wip @adopter` scenarios retain their
 - **Frontend error-handling first batch complete**: `@impl_frontend_global_error_boundary`, `@impl_frontend_not_found_page`, `@impl_frontend_error_page`, `@impl_frontend_error_recovery`, `@impl_frontend_error_logging`, and `@impl_frontend_accessible_errors` are now `@ready`.
 - **Frontend core expanded batch complete**: `@impl_frontend_typed_api_client`, `@impl_frontend_error_boundary_recovery`, `@impl_frontend_loading_state`, `@impl_frontend_debounce_hook`, `@impl_frontend_query_caching`, `@impl_frontend_offline_detection`, `@impl_frontend_semantic_accessibility`, `@impl_frontend_keyboard_navigation`, and `@impl_frontend_form_validation` are now `@ready`.
 - **Frontend base complete**: final Next.js scenarios for responsive layout, route-level authentication, custom error pages, and loading UI are now `@ready`; remaining frontend scenarios are explicitly `@adopter`.
-- **Pre-migration classification complete**: adopter-only frontend/security scenarios currently use `@wip @adopter`; the planned responsibility-taxonomy migration will preserve status separately and add explicit `@template` / `@adopter` ownership. E2E personas moderator implementation and BDD coverage merged in PR #64 with green CI.
+- **Responsibility migration complete**: every scenario has exactly one effective status and responsibility. All ready coverage is template-owned; all WIP guidance is adopter-owned. E2E personas moderator implementation and BDD coverage merged in PR #64 with green CI.

--- a/.github/prompts/plan-nextNodeAppBase.prompt.md
+++ b/.github/prompts/plan-nextNodeAppBase.prompt.md
@@ -466,14 +466,26 @@ Consequence: lower migration risk and clearer package boundaries.
 
 - ✅ **Review-driven semantic versioning (Changesets)** — `@changesets/cli`, private-package versioning config, a manually triggered and immutable-action-pinned Version Packages PR workflow, current 2026 changelog entries, and publishing guidance are complete. Version preparation and publishing remain explicit operator actions.
 
-1. **Contract package extraction** (Migration Plan step 6) — first bootstrapped fork will be `fasciculum-instrumentorum`; promote stable DTOs from `lib/contracts/` into `@repo/types` or a successor `@repo/contracts` package once that fork proves reuse.
-2. **Phase 11 Feature Management System** — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks. No code exists yet; begin with ADR and interface contracts in `packages/types`.
+1. **BDD responsibility taxonomy** — introduce `@template` / `@adopter` as a responsibility dimension independent of `@ready` / `@wip` / `@manual` / `@skip`; migrate governance, dashboard, profiles, scenarios, tests, and docs atomically.
+2. **Template-ready milestone release** — after the responsibility taxonomy merges, manually create the repository tag and GitHub release. Do not run package versioning or publishing: all workspace packages remain private and the current distribution goal is GitHub clone/template use.
+3. **Contract package extraction** (Migration Plan step 6) — first bootstrapped fork will be `fasciculum-instrumentorum`; promote stable DTOs from `lib/contracts/` into `@repo/types` or a successor `@repo/contracts` package once that fork proves reuse.
+4. **Phase 11 Feature Management System** — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks. No code exists yet; begin with ADR and interface contracts in `packages/types`.
 
 ## N. BDD Scenario Scope: Base Repo vs Adopter
 
 The dividing line: **base repo = infrastructure, conventions, and cross-cutting concerns the template wires up for any adopter; adopter = business domain logic, provider choices, production ops, and app-specific UX.**
 
-The `@ready` tag tracks only base-repo scenarios. Adopter scenarios stay `@wip @adopter` permanently in this repo and serve as implementation guides for teams forking the template.
+### Agreed taxonomy (planned)
+
+Status and responsibility are independent:
+
+- Every scenario has exactly one effective execution status: `@ready`, `@wip`, `@manual`, or `@skip`.
+- Every scenario has exactly one effective responsibility tag: `@template` or `@adopter`.
+- `@template` means the base repository owns the behavior; `@adopter` means the scenario is implementation guidance for a fork.
+- Feature-level tags may provide defaults, with explicit scenario-level overrides.
+- Default CI selects template-owned ready scenarios. Dashboard reporting defaults to template scope and provides an adopter-backlog preset.
+
+Until the migration is complete, existing `@wip @adopter` scenarios retain their current meaning. The migration must update governance scripts, API/dashboard types, filters and totals, Cucumber profiles, all feature files, tests, and documentation in one change.
 
 ### Base repo responsibility (complete)
 
@@ -493,7 +505,7 @@ The `@ready` tag tracks only base-repo scenarios. Adopter scenarios stay `@wip @
 | 12-kubernetes-devops | ~10/34 | Dockerfiles, Docker Compose, GitHub Actions CI, K8s manifest templates             |
 | Frontend base        | 32/32  | i18n, Next.js, ADR-011 frontend auth wiring, error handling, core hooks, a11y      |
 
-### Adopter responsibility (`@wip @adopter` permanently in this repo)
+### Adopter responsibility (migrate to responsibility-aware tagging)
 
 | Feature                      | Scope  | Notes                                                                              |
 | ---------------------------- | ------ | ---------------------------------------------------------------------------------- |
@@ -524,4 +536,4 @@ The `@ready` tag tracks only base-repo scenarios. Adopter scenarios stay `@wip @
 - **Frontend error-handling first batch complete**: `@impl_frontend_global_error_boundary`, `@impl_frontend_not_found_page`, `@impl_frontend_error_page`, `@impl_frontend_error_recovery`, `@impl_frontend_error_logging`, and `@impl_frontend_accessible_errors` are now `@ready`.
 - **Frontend core expanded batch complete**: `@impl_frontend_typed_api_client`, `@impl_frontend_error_boundary_recovery`, `@impl_frontend_loading_state`, `@impl_frontend_debounce_hook`, `@impl_frontend_query_caching`, `@impl_frontend_offline_detection`, `@impl_frontend_semantic_accessibility`, `@impl_frontend_keyboard_navigation`, and `@impl_frontend_form_validation` are now `@ready`.
 - **Frontend base complete**: final Next.js scenarios for responsive layout, route-level authentication, custom error pages, and loading UI are now `@ready`; remaining frontend scenarios are explicitly `@adopter`.
-- **Final classification cleanup complete**: adopter-only frontend/security scenarios are tagged `@adopter` and stay `@wip`. E2E personas moderator implementation and BDD coverage merged in PR #64 with green CI.
+- **Pre-migration classification complete**: adopter-only frontend/security scenarios currently use `@wip @adopter`; the planned responsibility-taxonomy migration will preserve status separately and add explicit `@template` / `@adopter` ownership. E2E personas moderator implementation and BDD coverage merged in PR #64 with green CI.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,25 +20,16 @@ on:
         type: string
         default: ""
 
-  # Publish on tags (for release automation)
-  push:
-    tags:
-      - "v*"
-
-  # Publish on GitHub releases
-  release:
-    types: [published]
-
 # Required permissions for GitHub Packages
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 env:
   NODE_VERSION: "25.x"
-  REGISTRY_URL_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['registry-url'] || '' }}
-  DRY_RUN_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['dry-run'] || '' }}
-  PACKAGES_FILTER_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['packages-filter'] || '' }}
+  REGISTRY_URL_INPUT: ${{ github.event.inputs['registry-url'] }}
+  DRY_RUN_INPUT: ${{ github.event.inputs['dry-run'] }}
+  PACKAGES_FILTER_INPUT: ${{ github.event.inputs['packages-filter'] }}
 
 jobs:
   build:
@@ -99,14 +90,7 @@ jobs:
 
       - name: Determine dry-run mode
         id: dry-run
-        run: |
-          # Manual dispatch: use input
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "enabled=$DRY_RUN_INPUT" >> "$GITHUB_OUTPUT"
-          # Tag/release: always publish for real
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "enabled=$DRY_RUN_INPUT" >> "$GITHUB_OUTPUT"
 
       - name: Publish packages (dry-run)
         if: steps.dry-run.outputs.enabled == 'true'
@@ -142,42 +126,3 @@ jobs:
             echo ""
             echo "Check the logs above for detailed publish results."
           } >> "$GITHUB_STEP_SUMMARY"
-
-  # Optional: Create GitHub release notes with published packages
-  release-notes:
-    name: Update Release Notes
-    runs-on: ubuntu-latest
-    needs: publish
-    if: github.event_name == 'release'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Get published packages
-        id: packages
-        run: |
-          # Extract package names and versions from packages/*
-          packages=$(find packages -name 'package.json' -not -path '*/node_modules/*' -exec jq -r 'select(.private == false) | "\(.name)@\(.version)"' {} \; | paste -sd "," -)
-          echo "list=$packages" >> "$GITHUB_OUTPUT"
-
-      - name: Add packages to release notes
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const packages = '${{ steps.packages.outputs.list }}'.split(',').filter(Boolean);
-            if (packages.length === 0) {
-              console.log('No publishable packages found');
-              return;
-            }
-
-            const packageList = packages.map(pkg => `- \`${pkg}\``).join('\n');
-            const body = `## Published Packages\n\n${packageList}\n\n---\n\n${context.payload.release.body}`;
-
-            await github.rest.repos.updateRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              release_id: context.payload.release.id,
-              body: body
-            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added independent `@template` / `@adopter` BDD responsibility governance, template-scoped default Cucumber profiles, and scope-aware dashboard filters with an adopter-backlog preset
 - Upgraded to Node.js 25 for native TypeScript support ([ADR-001](docs/adr/001-node-js-25-native-typescript.md))
 - Updated `.nvmrc` to Node.js 25
 - Updated Dev Container to use `node:25-bookworm`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -115,11 +115,13 @@ The backend core is implemented and running.
 
 ## Current Focus / Next Steps
 
-### Current Objective: BDD Base-Repo Scenario Coverage Complete
+### Current Objective: Responsibility-Aware BDD Governance
 
-**Goal:** Promote all base-repo scenarios to `@ready`. Adopter scenarios remain `@wip @adopter` permanently — they are implementation guides for teams forking the template, not coverage obligations here. See [plan prompt](.github/prompts/plan-nextNodeAppBase.prompt.md) section N for the full base-vs-adopter scope tables.
+**Goal:** Separate scenario execution status from coverage responsibility. Every scenario will have one effective status (`@ready`, `@wip`, `@manual`, or `@skip`) and one effective responsibility tag (`@template` or `@adopter`). See [plan prompt](.github/prompts/plan-nextNodeAppBase.prompt.md) section N.
 
-**Current tracked status (July 31, 2026):** backend 140/266 ready; frontend 31/121 ready; overall 171/387 ready. Frontend/security adopter-only scenarios are explicitly classified with `@adopter`. The new backend-ready scenario covers the deterministic moderator E2E persona contract.
+**Pre-migration baseline (July 31, 2026):** backend 140/266 ready; frontend 31/121 ready; overall 171/387 ready. The current 216 WIP count mixes genuine template backlog with adopter guidance and must not be interpreted as unfinished template coverage.
+
+**Decision recorded August 4, 2026:** retain status and responsibility as independent dimensions. Use `@template` rather than `@native` for unambiguous ownership. Update governance, reports, dashboard filters/totals, Cucumber profiles, feature tags, tests, and documentation together. Default dashboard reporting should show template scope; provide an adopter-backlog preset.
 
 **Priority order** (highest coverage gap first):
 
@@ -159,6 +161,8 @@ The backend core is implemented and running.
 ### Up Next
 
 - [x] Review-driven semantic versioning (Changesets) — added `@changesets/cli`, version-only package scripts/config, a manually triggered and immutable-action-pinned Version Packages PR workflow, publishing guidance, and current 2026 `CHANGELOG.md` entries
+- [ ] BDD responsibility taxonomy — add mutually exclusive `@template` / `@adopter` scope tags alongside status, migrate all scenarios, and add scope-aware governance and dashboard reporting
+- [ ] Template-ready milestone release — after the BDD taxonomy work merges, manually create the repository tag and GitHub release; no package publication or Changesets version PR is planned
 - [ ] Contract package extraction — promote stable DTOs into `@repo/contracts` once `fasciculum-instrumentorum` fork proves reuse
 - [ ] Phase 11 Feature Management System — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks; begin with ADR and interface contracts
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -119,9 +119,9 @@ The backend core is implemented and running.
 
 **Goal:** Separate scenario execution status from coverage responsibility. Every scenario will have one effective status (`@ready`, `@wip`, `@manual`, or `@skip`) and one effective responsibility tag (`@template` or `@adopter`). See [plan prompt](.github/prompts/plan-nextNodeAppBase.prompt.md) section N.
 
-**Pre-migration baseline (July 31, 2026):** backend 140/266 ready; frontend 31/121 ready; overall 171/387 ready. The current 216 WIP count mixes genuine template backlog with adopter guidance and must not be interpreted as unfinished template coverage.
+**Responsibility baseline (August 4, 2026):** backend 140/266 ready; frontend 31/121 ready; overall 171/387 ready. All 171 ready scenarios are template-owned; the 216 WIP scenarios are adopter-owned implementation guidance and are excluded from the default template CI/dashboard scope.
 
-**Decision recorded August 4, 2026:** retain status and responsibility as independent dimensions. Use `@template` rather than `@native` for unambiguous ownership. Update governance, reports, dashboard filters/totals, Cucumber profiles, feature tags, tests, and documentation together. Default dashboard reporting should show template scope; provide an adopter-backlog preset.
+**Implemented August 4, 2026:** status and responsibility are independent dimensions. `@template` / `@adopter` ownership is enforced alongside execution status. Governance, reports, dashboard filters/totals, Cucumber profiles, feature tags, tests, and documentation are scope-aware. The dashboard defaults to template scope and includes an adopter-backlog preset.
 
 **Priority order** (highest coverage gap first):
 
@@ -161,7 +161,7 @@ The backend core is implemented and running.
 ### Up Next
 
 - [x] Review-driven semantic versioning (Changesets) — added `@changesets/cli`, version-only package scripts/config, a manually triggered and immutable-action-pinned Version Packages PR workflow, publishing guidance, and current 2026 `CHANGELOG.md` entries
-- [ ] BDD responsibility taxonomy — add mutually exclusive `@template` / `@adopter` scope tags alongside status, migrate all scenarios, and add scope-aware governance and dashboard reporting
+- [x] BDD responsibility taxonomy — added mutually exclusive `@template` / `@adopter` scope tags alongside status, migrated all 387 scenarios, and added scope-aware governance, Cucumber profiles, and dashboard reporting
 - [ ] Template-ready milestone release — after the BDD taxonomy work merges, manually create the repository tag and GitHub release; no package publication or Changesets version PR is planned
 - [ ] Contract package extraction — promote stable DTOs into `@repo/contracts` once `fasciculum-instrumentorum` fork proves reuse
 - [ ] Phase 11 Feature Management System — `IFeatureFlagService`, evaluation engine, flag CRUD API, React hooks; begin with ADR and interface contracts

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ BDD status:
 
 The [BDD implementer coverage reference](docs/BDD.md#implementer-coverage-reference) explains how to browse every scenario and isolate the `@wip @adopter` implementation backlog in the admin-only BDD dashboard. See also the [testing documentation](docs/TESTING.md) and [E2E guide](apps/frontend/docs/E2E_TESTING.md).
 
+The next governance update will separate responsibility (`@template` / `@adopter`) from execution status and make dashboard totals scope-aware.
+
 ## Versioning and Publishing
 
 Changesets manages package versions independently:
@@ -129,6 +131,8 @@ Changesets manages package versions independently:
 4. Publish explicitly through the Publish Packages workflow after the intended package is marked publishable.
 
 Repository/template releases are separate Git tags and GitHub releases. Repository-only documentation, CI, and tooling changes do not require artificial package changesets. See [Publishing Packages](docs/PUBLISHING.md).
+
+The current distribution goal is repository cloning and GitHub's **Use this template** flow, not package publication. The next template milestone tag and GitHub release will be created manually after the planned BDD responsibility-taxonomy change is merged.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A production-oriented starter repository for a Next.js frontend and an Express b
 - Changesets package versioning with a reviewable Version Packages pull request
 - Security, ADR, workflow-linting, and dependency-governance foundations
 
-Adopter-specific scenarios remain tagged @wip @adopter as implementation guides. See [PROGRESS.md](PROGRESS.md) for current scope and priorities.
+Adopter-specific scenarios are tagged `@wip @adopter` as implementation guides and are separate from template-owned coverage. See [PROGRESS.md](PROGRESS.md) for current scope and priorities.
 
 ## Prerequisites
 
@@ -113,13 +113,13 @@ Playwright starts the frontend and backend automatically for E2E runs and uses d
 
 BDD status:
 
-- @ready: implemented base-repository behavior in the default BDD gate
-- @wip @adopter: guidance for applications created from this template
+- `@ready @template`: implemented base-repository behavior in the default BDD gate
+- `@wip @adopter`: guidance for applications created from this template
 - @manual: behavior requiring manual verification
 
 The [BDD implementer coverage reference](docs/BDD.md#implementer-coverage-reference) explains how to browse every scenario and isolate the `@wip @adopter` implementation backlog in the admin-only BDD dashboard. See also the [testing documentation](docs/TESTING.md) and [E2E guide](apps/frontend/docs/E2E_TESTING.md).
 
-The next governance update will separate responsibility (`@template` / `@adopter`) from execution status and make dashboard totals scope-aware.
+Responsibility (`@template` / `@adopter`) is independent from execution status. Dashboard totals and filters are scope-aware and default to template-owned scenarios.
 
 ## Versioning and Publishing
 

--- a/apps/backend/cucumber.js
+++ b/apps/backend/cucumber.js
@@ -34,7 +34,7 @@ module.exports = {
   // Default: run only scenarios explicitly marked as implemented.
   default: {
     ...common,
-    tags: '@ready and not @skip',
+    tags: '@template and @ready and not @skip',
   },
   // Run everything (useful locally once step definitions are complete).
   all: {
@@ -45,6 +45,10 @@ module.exports = {
   wip: {
     ...common,
     tags: '@wip and not @skip',
+  },
+  adopter: {
+    ...common,
+    tags: '@adopter and not @skip',
   },
   // Run only manual/ops requirements.
   manual: {

--- a/apps/backend/features/01-foundation.feature
+++ b/apps/backend/features/01-foundation.feature
@@ -1,3 +1,4 @@
+@template
 Feature: Project Foundation and Governance
   As a development team
   We need a solid monorepo foundation with code quality standards

--- a/apps/backend/features/02-security.feature
+++ b/apps/backend/features/02-security.feature
@@ -17,6 +17,7 @@ Feature: Security Framework
     And singleton services should maintain state
 
   @ready @security @jwt @impl_jwt_authentication
+  @template
   Scenario: JWT token generation and validation
     Given a user with valid credentials
     When I generate a JWT token for the user
@@ -28,6 +29,7 @@ Feature: Security Framework
     And user information should be extracted correctly
 
   @ready @security @jwt-expiration @impl_jwt_expiration
+  @template
   Scenario: JWT token expiration handling
     Given an expired JWT token
     When I attempt to validate the expired token
@@ -94,6 +96,7 @@ Feature: Security Framework
 
   @security @authorization @audit-log @impl_authz_own_audit
   @ready
+  @template
   Scenario: Owner-based authorization and audit logging
     Given AuthorizationService and AuditLogService are configured
     When user "user-123" is granted permission "posts:update:own"
@@ -116,6 +119,7 @@ Feature: Security Framework
     And ABAC policy should be evaluated correctly
 
   @ready @security @rate-limiting @impl_rate_limiting
+  @template
   Scenario: Rate limiting for API endpoints
     Given rate limiting is enabled for endpoint "/api/auth/login"
     And the limit is 5 requests per minute
@@ -126,6 +130,7 @@ Feature: Security Framework
     And I should receive a 429 status code
 
   @ready @security @owasp @helmet @impl_helmet_security_headers
+  @template
   Scenario: OWASP Top 10 protection with Helmet.js
     Given Helmet.js is configured for Express
     When I make a request to any API endpoint
@@ -138,6 +143,7 @@ Feature: Security Framework
       | Content-Security-Policy     |
 
   @ready @security @cors @impl_cors_allowed_origins
+  @template
   Scenario: CORS configuration for allowed origins
     Given CORS is configured with allowed origins
     When I make a request from origin "<origin>"
@@ -171,6 +177,7 @@ Feature: Security Framework
       | access  | admin-panel   |
 
   @ready @security @input-validation @impl_input_validation_sanitization
+  @template
   Scenario: Input validation and sanitization
     Given input validation is configured
     When I submit data with malicious input "<input>"
@@ -186,6 +193,7 @@ Feature: Security Framework
 
   @security @secrets-management @impl_secrets_management_env
   @ready
+  @template
   Scenario: Environment-based secrets management
     Given secrets are stored in environment variables
     When the application starts
@@ -194,6 +202,7 @@ Feature: Security Framework
     And secrets should be different per environment
 
   @ready @security @auth-contract @backend-only @impl_backend_only_auth_contract
+  @template
   Scenario: ADR-011 backend-only authentication contract
     Given the ADR-011 backend auth contract source is loaded
     Then backend auth routes should expose login, refresh, logout, and current-user endpoints

--- a/apps/backend/features/03-backend-core.feature
+++ b/apps/backend/features/03-backend-core.feature
@@ -9,6 +9,7 @@ Feature: Backend Core Services
     And environment variables are configured
 
   @ready @backend @express @impl_express_init
+  @template
   Scenario: Express server initialization
     Given Express is configured with middleware
     When the server starts
@@ -17,6 +18,7 @@ Feature: Backend Core Services
     And error handling should be configured
 
   @ready @backend @database @prisma @impl_prisma_connection
+  @template
   Scenario: Prisma ORM database connection
     Given Prisma is configured for PostgreSQL
     When the application connects to the database
@@ -25,6 +27,7 @@ Feature: Backend Core Services
     And migrations should be up to date
 
   @ready @backend @database @crud @impl_user_crud
+  @template
   Scenario: Database CRUD operations
     Given a User model exists in the database
     When I create a new user with data:
@@ -42,6 +45,7 @@ Feature: Backend Core Services
     Then the user should be removed from the database
 
   @ready @backend @cache @redis @impl_redis_cache
+  @template
   Scenario: Redis caching service
     Given Redis is configured and running
     When I set a cache key "test-key" with value "test-value"
@@ -53,6 +57,7 @@ Feature: Backend Core Services
     Then the cache key should be expired
 
   @ready @backend @cache @invalidation @impl_cache_invalidation
+  @template
   Scenario: Cache invalidation strategies
     Given cached data exists for key "user:123"
     When the underlying data is updated
@@ -61,6 +66,7 @@ Feature: Backend Core Services
     And the fresh data should be cached
 
   @ready @backend @logging @winston @impl_winston_logging
+  @template
   Scenario: Winston logging service
     Given Winston is configured with multiple transports
     When I log a message at level "<level>"
@@ -76,6 +82,7 @@ Feature: Backend Core Services
       | debug |
 
   @ready @backend @logging @correlation-id @impl_correlation_id
+  @template
   Scenario: Request correlation ID tracking
     Given correlation ID middleware is enabled
     When I make an API request
@@ -84,6 +91,7 @@ Feature: Backend Core Services
     And all logs for this request should include the correlation ID
 
   @ready @backend @error-handling @impl_error_handler
+  @template
   Scenario: Global error handling middleware
     Given global error handler is configured
     When an unhandled error occurs in a route
@@ -93,6 +101,7 @@ Feature: Backend Core Services
     And in production, stack traces should be hidden
 
   @ready @backend @health-check @impl_health_check
+  @template
   Scenario: Health check endpoint
     Given the application is running
     When I request GET "/health"
@@ -104,6 +113,7 @@ Feature: Backend Core Services
       | status    |
 
   @backend @readiness-check @impl_readiness_check
+  @adopter
   Scenario: Readiness check with dependencies
     Given the application is running
     And database is connected
@@ -115,6 +125,7 @@ Feature: Backend Core Services
     And cache health should be "true"
 
   @backend @readiness-check @failure
+  @adopter
   Scenario: Readiness check when dependencies fail
     Given the application is running
     And database is disconnected
@@ -124,6 +135,7 @@ Feature: Backend Core Services
     And database health should be "false"
 
   @backend @middleware @compression @impl_compression
+  @adopter
   Scenario: Response compression middleware
     Given compression middleware is enabled
     When I request a large JSON response
@@ -131,6 +143,7 @@ Feature: Backend Core Services
     And the Content-Encoding header should be "gzip"
 
   @ready @backend @middleware @cors @impl_cors
+  @template
   Scenario: CORS middleware configuration
     Given CORS is configured for allowed origins
     When I make a preflight OPTIONS request
@@ -139,6 +152,7 @@ Feature: Backend Core Services
     And credentials should be allowed for trusted origins
 
   @ready @backend @webhooks @impl_webhooks
+  @template
   Scenario: Webhook event publishing
     Given a webhook service is configured
     And a webhook subscriber is registered for event "<event>"
@@ -154,6 +168,7 @@ Feature: Backend Core Services
       | order.completed |
 
   @ready @backend @webhooks @security @impl_webhooks
+  @template
   Scenario: Webhook signature verification
     Given webhooks have signature verification enabled
     When a webhook is received with a valid signature
@@ -163,6 +178,7 @@ Feature: Backend Core Services
     And an error should be logged
 
   @ready @backend @database @transactions @impl_db_transactions
+  @template
   Scenario: Database transactions for atomic operations
     Given multiple database operations need to be atomic
     When I start a transaction
@@ -175,6 +191,7 @@ Feature: Backend Core Services
     And no changes should be persisted
 
   @ready @backend @database @soft-delete @impl_soft_delete
+  @template
   Scenario: Soft delete implementation
     Given a User model with soft delete support
     When I soft delete a user
@@ -185,6 +202,7 @@ Feature: Backend Core Services
     Then the soft deleted user should not be included
 
   @backend @middleware @request-validation @impl_request_validation
+  @adopter
   Scenario: Request body validation
     Given request validation middleware is configured
     When I POST to "/api/users" with invalid data
@@ -193,6 +211,7 @@ Feature: Backend Core Services
     And validation errors should be detailed in the response
 
   @ready @backend @graceful-shutdown @impl_graceful_shutdown
+  @template
   Scenario: Graceful server shutdown
     Given the server is running with active connections
     When a shutdown signal is received

--- a/apps/backend/features/05-testing.feature
+++ b/apps/backend/features/05-testing.feature
@@ -9,6 +9,7 @@ Feature: Testing Infrastructure
 
   @testing @resilience @external-services @impl_test_resilience_external_services
   @ready
+  @template
   Scenario: Backend tests are resilient without external services
     Given backend test setup forces external service mocks
     And backend CI test runner forces external service mocks
@@ -16,6 +17,7 @@ Feature: Testing Infrastructure
     And Redis and database integration tests should be skippable when external services are disabled
 
   @testing @vitest @unit
+  @adopter
   Scenario: Vitest unit testing for backend
     Given Vitest is configured for unit tests
     When I run unit tests for a service
@@ -24,6 +26,7 @@ Feature: Testing Infrastructure
     And coverage reports should be generated
 
   @testing @vitest @integration
+  @adopter
   Scenario: Integration testing with Vitest
     Given integration tests are defined
     When I run integration tests
@@ -32,6 +35,7 @@ Feature: Testing Infrastructure
     And tests should run in isolation
 
   @testing @playwright @e2e
+  @adopter
   Scenario: Playwright E2E testing
     Given Playwright is configured for E2E tests
     When I run E2E tests for user flow "<flow>"
@@ -46,6 +50,7 @@ Feature: Testing Infrastructure
       | dashboard access  |
 
   @testing @e2e @seeding
+  @adopter
   Scenario: Deterministic E2E seeding via HTTP endpoint
     Given the backend exposes a dev-only seed endpoint at "POST /api/e2e/seed"
     And the endpoint is blocked when NODE_ENV is "production"
@@ -56,6 +61,7 @@ Feature: Testing Infrastructure
     And the seeded state should be consistent across runs
 
   @ready @no-server @testing @e2e @seeding @moderator @impl_e2e_moderator_persona
+  @template
   Scenario: Deterministic moderator E2E persona contract
     Given the moderator E2E persona contract sources are loaded
     Then backend default seed personas should include moderator@example.com with role MODERATOR
@@ -64,6 +70,7 @@ Feature: Testing Infrastructure
     And development fallback login should authenticate the moderator with role MODERATOR
 
   @testing @coverage
+  @adopter
   Scenario: Code coverage thresholds
     Given coverage thresholds are configured
     When I run tests with coverage
@@ -72,6 +79,7 @@ Feature: Testing Infrastructure
     And function coverage should be at least 80%
 
   @testing @supertest
+  @adopter
   Scenario: API endpoint testing with Supertest
     Given Supertest is configured for API testing
     When I test POST "/api/users" endpoint
@@ -80,6 +88,7 @@ Feature: Testing Infrastructure
     And I should assert on status codes and body
 
   @testing @mocking
+  @adopter
   Scenario: Service mocking and stubbing
     Given a service depends on external dependencies
     When I write unit tests for the service
@@ -88,6 +97,7 @@ Feature: Testing Infrastructure
     And tests should not depend on external services
 
   @testing @fixtures
+  @adopter
   Scenario: Test data fixtures
     Given test fixtures are defined
     When I run tests that need sample data
@@ -96,6 +106,7 @@ Feature: Testing Infrastructure
     And fixtures should be cleaned up after tests
 
   @testing @snapshot
+  @adopter
   Scenario: Snapshot testing for UI components
     Given snapshot tests are configured
     When I render a component
@@ -105,6 +116,7 @@ Feature: Testing Infrastructure
     And developers should review and update snapshots
 
   @testing @parallel
+  @adopter
   Scenario: Parallel test execution
     Given test suite has multiple test files
     When I run tests in parallel mode
@@ -113,6 +125,7 @@ Feature: Testing Infrastructure
     And tests should not interfere with each other
 
   @testing @watch-mode
+  @adopter
   Scenario: Watch mode for development
     Given watch mode is enabled
     When I change a source file

--- a/apps/backend/features/06-notifications.feature
+++ b/apps/backend/features/06-notifications.feature
@@ -10,6 +10,7 @@ Feature: Notification Service Abstraction
 
   @notifications @email @impl_notifications
   @ready
+  @template
   Scenario: Send email notification
     Given email provider is configured
     When I send an email to "user@example.com" with subject "Welcome"
@@ -18,6 +19,7 @@ Feature: Notification Service Abstraction
     And delivery status should be tracked
 
   @notifications @email @sendgrid
+  @adopter
   Scenario: SendGrid email provider
     Given EMAIL_PROVIDER is set to "sendgrid"
     And SendGrid API key is configured
@@ -27,6 +29,7 @@ Feature: Notification Service Abstraction
     And delivery should be confirmed
 
   @notifications @email @console
+  @adopter
   Scenario: Console email provider for development
     Given EMAIL_PROVIDER is set to "console"
     When I send an email in development mode
@@ -36,6 +39,7 @@ Feature: Notification Service Abstraction
 
   @notifications @sms @impl_notifications_sms
   @ready
+  @template
   Scenario: Send SMS notification
     Given SMS provider is configured
     When I send an SMS to "+1234567890" with message "Verification code: 123456"
@@ -44,6 +48,7 @@ Feature: Notification Service Abstraction
     And delivery status should be tracked
 
   @notifications @sms @twilio
+  @adopter
   Scenario: Twilio SMS provider
     Given SMS_PROVIDER is set to "twilio"
     And Twilio credentials are configured
@@ -54,6 +59,7 @@ Feature: Notification Service Abstraction
 
   @notifications @push @impl_notifications_push
   @ready
+  @template
   Scenario: Send push notification
     Given push notification provider is configured
     When I send a push notification to device token "<token>"
@@ -67,6 +73,7 @@ Feature: Notification Service Abstraction
       | fcm-token-456-device-ios               |
 
   @notifications @push @fcm
+  @adopter
   Scenario: Firebase Cloud Messaging push provider
     Given PUSH_PROVIDER is set to "fcm"
     And Firebase credentials are configured
@@ -76,6 +83,7 @@ Feature: Notification Service Abstraction
     And delivery should be confirmed
 
   @notifications @bulk-email
+  @adopter
   Scenario: Send bulk email notifications
     Given email provider supports bulk sending
     When I send bulk emails to 100 recipients
@@ -84,6 +92,7 @@ Feature: Notification Service Abstraction
     And all deliveries should be tracked
 
   @notifications @templates
+  @adopter
   Scenario: Email template rendering
     Given email templates are defined
     When I send an email using template "welcome-email"
@@ -95,6 +104,7 @@ Feature: Notification Service Abstraction
     And the email should contain personalized content
 
   @notifications @attachments
+  @adopter
   Scenario: Send email with attachments
     Given an email with attachments
     When I send an email with PDF attachment
@@ -104,6 +114,7 @@ Feature: Notification Service Abstraction
 
   @notifications @retry @impl_notifications
   @ready
+  @template
   Scenario: Notification delivery retry logic
     Given a notification fails to deliver
     When the initial delivery attempt fails
@@ -113,6 +124,7 @@ Feature: Notification Service Abstraction
 
   @notifications @health-check @impl_notifications
   @ready
+  @template
   Scenario: Notification service health check
     Given notification providers are configured
     When I check notification service health
@@ -121,6 +133,7 @@ Feature: Notification Service Abstraction
     And push provider status should be reported
 
   @notifications @provider-switching
+  @adopter
   Scenario: Switch notification providers via environment variables
     Given notification service uses dependency injection
     When I change EMAIL_PROVIDER from "console" to "sendgrid"
@@ -129,6 +142,7 @@ Feature: Notification Service Abstraction
     And emails should be sent via the new provider
 
   @notifications @error-handling
+  @adopter
   Scenario: Handle notification delivery failures
     Given email provider is unavailable
     When I attempt to send an email
@@ -137,6 +151,7 @@ Feature: Notification Service Abstraction
     And the user should be notified of the failure
 
   @notifications @logging
+  @adopter
   Scenario: Notification delivery logging
     Given notification logging is enabled
     When any notification is sent

--- a/apps/backend/features/07-api-design.feature
+++ b/apps/backend/features/07-api-design.feature
@@ -10,6 +10,7 @@ Feature: API Design Patterns
 
   @api @versioning @header
   @ready @impl_api_versioning
+  @template
   Scenario: Header-based API versioning
     Given API versioning is configured
     When I make a request with Accept header "application/vnd.api+json; version=1.0"
@@ -18,6 +19,7 @@ Feature: API Design Patterns
 
   @api @versioning @fallback
   @ready @impl_api_versioning
+  @template
   Scenario: Default API version fallback
     Given API versioning is configured with default version 1.0
     When I make a request without version header
@@ -25,12 +27,14 @@ Feature: API Design Patterns
 
   @api @versioning @unsupported
   @ready @impl_api_versioning
+  @template
   Scenario: Unsupported API version handling
     When I make a request with Accept header "application/vnd.api+json; version=99.0"
     Then the response status should be 400
     And the response should indicate unsupported version
 
   @api @hateoas
+  @adopter
   Scenario: HATEOAS links in API responses
     Given HATEOAS is enabled for API endpoints
     When I GET "/api/users/123"
@@ -40,6 +44,7 @@ Feature: API Design Patterns
     And "_links" should contain "delete" link
 
   @api @hateoas @pagination
+  @adopter
   Scenario: HATEOAS pagination links
     Given a collection endpoint with multiple pages
     When I GET "/api/users?page=2&pageSize=10"
@@ -52,6 +57,7 @@ Feature: API Design Patterns
       | last  |
 
   @api @pagination
+  @adopter
   Scenario: Pagination with query parameters
     Given a collection of 50 users exists
     When I GET "/api/users?page=<page>&pageSize=<pageSize>"
@@ -66,6 +72,7 @@ Feature: API Design Patterns
       | 6    | 10       | 0     |
 
   @api @filtering
+  @adopter
   Scenario: Resource filtering with query operators
     Given users exist in the database
     When I GET "/api/users?filter=<filter>"
@@ -79,12 +86,14 @@ Feature: API Design Patterns
       | age[gt]=18                      |
 
   @api @filtering @multiple
+  @adopter
   Scenario: Multiple filter conditions
     Given users exist with various attributes
     When I GET "/api/users?filter=role[eq]=admin&filter=status[eq]=active"
     Then only users matching all conditions should be returned
 
   @api @sorting
+  @adopter
   Scenario: Resource sorting
     Given users exist in the database
     When I GET "/api/users?sort=<sortField>&order=<order>"
@@ -97,6 +106,7 @@ Feature: API Design Patterns
       | name      | asc   |
 
   @api @sorting @multiple
+  @adopter
   Scenario: Multi-field sorting
     Given users exist in the database
     When I GET "/api/users?sort=role,createdAt&order=asc,desc"
@@ -105,6 +115,7 @@ Feature: API Design Patterns
 
   @api @swagger
   @ready @impl_openapi_docs
+  @template
   Scenario: Swagger/OpenAPI documentation
     Given Swagger is configured
     When I navigate to "/api-docs"
@@ -115,6 +126,7 @@ Feature: API Design Patterns
 
   @api @swagger @schemas
   @ready @impl_openapi_docs
+  @template
   Scenario: OpenAPI schema definitions
     Given OpenAPI specifications are defined
     When I view the Swagger documentation
@@ -128,6 +140,7 @@ Feature: API Design Patterns
 
   @api @swagger @security
   @ready @impl_openapi_docs
+  @template
   Scenario: Swagger security schemes
     Given security schemes are defined in Swagger
     When I view API endpoints in Swagger
@@ -136,6 +149,7 @@ Feature: API Design Patterns
     And I should be able to authenticate via Swagger UI
 
   @api @rate-limiting @endpoint
+  @adopter
   Scenario: Per-endpoint rate limiting
     Given rate limiting is configured for "/api/users"
     And the limit is 100 requests per minute
@@ -145,6 +159,7 @@ Feature: API Design Patterns
     Then the request should be rejected with 429 status
 
   @api @compression
+  @adopter
   Scenario: Response compression for large payloads
     Given compression middleware is enabled
     When I request a large collection endpoint
@@ -153,6 +168,7 @@ Feature: API Design Patterns
     And response size should be significantly reduced
 
   @api @etag
+  @adopter
   Scenario: ETag caching for conditional requests
     Given ETags are enabled for resource endpoints
     When I GET "/api/users/123"
@@ -162,6 +178,7 @@ Feature: API Design Patterns
     And no body should be returned
 
   @api @content-negotiation
+  @adopter
   Scenario: Content type negotiation
     When I request "/api/users" with Accept header "application/json"
     Then the response Content-Type should be "application/json"
@@ -169,6 +186,7 @@ Feature: API Design Patterns
     Then the response status should be 406 Not Acceptable
 
   @api @error-response
+  @adopter
   Scenario: Standardized error responses
     Given API error handling is configured
     When an error occurs during request processing
@@ -180,6 +198,7 @@ Feature: API Design Patterns
       | path    |
 
   @api @query-validation
+  @adopter
   Scenario: Query parameter validation
     Given query parameter validation is enabled
     When I GET "/api/users?page=<page>&pageSize=<pageSize>"

--- a/apps/backend/features/08-file-storage.feature
+++ b/apps/backend/features/08-file-storage.feature
@@ -10,6 +10,7 @@ Feature: File Storage Abstraction
 
   @storage @local @impl_storage_local_provider
   @ready
+  @template
   Scenario: Local filesystem storage
     Given STORAGE_PROVIDER is set to "local"
     When I upload a file to local storage
@@ -18,6 +19,7 @@ Feature: File Storage Abstraction
     And the file should be accessible via URL
 
   @storage @s3
+  @adopter
   Scenario: AWS S3 storage
     Given STORAGE_PROVIDER is set to "s3"
     And AWS credentials are configured
@@ -27,6 +29,7 @@ Feature: File Storage Abstraction
     And file metadata should include S3 URL
 
   @storage @azure
+  @adopter
   Scenario: Azure Blob Storage
     Given STORAGE_PROVIDER is set to "azure"
     And Azure Storage credentials are configured
@@ -36,6 +39,7 @@ Feature: File Storage Abstraction
     And file metadata should include Azure URL
 
   @storage @gcp
+  @adopter
   Scenario: Google Cloud Storage
     Given STORAGE_PROVIDER is set to "gcp"
     And GCP credentials are configured
@@ -46,6 +50,7 @@ Feature: File Storage Abstraction
 
   @storage @upload @single @impl_storage_upload_single
   @ready
+  @template
   Scenario: Upload a single file
     When I upload a file with:
       | field       | value              |
@@ -65,6 +70,7 @@ Feature: File Storage Abstraction
 
   @storage @upload @multiple @impl_storage_upload_multiple
   @ready
+  @template
   Scenario: Upload multiple files
     When I upload 3 files simultaneously
     Then all files should be stored successfully
@@ -73,6 +79,7 @@ Feature: File Storage Abstraction
 
   @storage @download @impl_storage_download
   @ready
+  @template
   Scenario: Download a file
     Given a file "documents/report.pdf" exists in storage
     When I download the file
@@ -81,6 +88,7 @@ Feature: File Storage Abstraction
 
   @storage @signed-url @impl_storage_signed_url
   @ready
+  @template
   Scenario: Generate signed URL for temporary access
     Given a file exists in storage
     When I request a signed URL with expiration 3600 seconds
@@ -90,6 +98,7 @@ Feature: File Storage Abstraction
 
   @storage @delete @impl_storage_delete
   @ready
+  @template
   Scenario: Delete a file
     Given a file "temp/old-file.txt" exists in storage
     When I delete the file
@@ -97,6 +106,7 @@ Feature: File Storage Abstraction
     And the file should no longer be accessible
 
   @storage @delete @multiple
+  @adopter
   Scenario: Delete multiple files
     Given 5 files exist in "temp/" folder
     When I delete all files in the folder
@@ -105,6 +115,7 @@ Feature: File Storage Abstraction
 
   @storage @exists @impl_storage_exists
   @ready
+  @template
   Scenario: Check if file exists
     When I check if "documents/report.pdf" exists
     Then existence check should return true
@@ -113,6 +124,7 @@ Feature: File Storage Abstraction
 
   @storage @list @impl_storage_list
   @ready
+  @template
   Scenario: List files in a folder
     Given 10 files exist in "images/" folder
     When I list files in "images/" folder
@@ -120,12 +132,14 @@ Feature: File Storage Abstraction
     And the list should contain 10 items
 
   @storage @list @prefix
+  @adopter
   Scenario: List files with prefix filter
     Given files exist with various prefixes
     When I list files with prefix "user-123-"
     Then only files matching the prefix should be returned
 
   @storage @list @pagination
+  @adopter
   Scenario: List files with pagination
     Given 100 files exist in storage
     When I list files with maxResults=20
@@ -133,6 +147,7 @@ Feature: File Storage Abstraction
     And a continuation token should be provided
 
   @storage @metadata
+  @adopter
   Scenario: Get file metadata
     Given a file exists in storage
     When I request metadata for the file
@@ -145,6 +160,7 @@ Feature: File Storage Abstraction
       | bucket       |
 
   @storage @copy
+  @adopter
   Scenario: Copy a file
     Given a file "original/file.txt" exists
     When I copy the file to "backup/file.txt"
@@ -153,6 +169,7 @@ Feature: File Storage Abstraction
     And metadata for the copy should be returned
 
   @storage @move
+  @adopter
   Scenario: Move a file
     Given a file "temp/file.txt" exists
     When I move the file to "archive/file.txt"
@@ -162,6 +179,7 @@ Feature: File Storage Abstraction
 
   @storage @validation @file-type @impl_storage_mime_validation
   @ready
+  @template
   Scenario: File type validation
     Given allowed MIME types are configured
     When I upload a file with MIME type "<mimeType>"
@@ -176,6 +194,7 @@ Feature: File Storage Abstraction
 
   @storage @validation @file-size @impl_storage_size_validation
   @ready
+  @template
   Scenario: File size validation
     Given maximum file size is 5MB
     When I upload a file of size "<size>"
@@ -189,6 +208,7 @@ Feature: File Storage Abstraction
 
   @storage @validation @filename @impl_storage_filename_sanitization
   @ready
+  @template
   Scenario: Filename sanitization
     When I upload a file with filename "<filename>"
     Then the filename should be sanitized to "<sanitized>"
@@ -201,6 +221,7 @@ Feature: File Storage Abstraction
       | .hidden                 | hidden              |
 
   @storage @multer @single-upload
+  @adopter
   Scenario: Multer single file upload endpoint
     When I POST to "/api/files/upload" with file in "file" field
     Then the file should be uploaded
@@ -208,6 +229,7 @@ Feature: File Storage Abstraction
     And authentication should be required
 
   @storage @multer @multiple-upload
+  @adopter
   Scenario: Multer multiple files upload endpoint
     When I POST to "/api/files/upload/multiple" with 3 files
     Then all files should be uploaded
@@ -215,6 +237,7 @@ Feature: File Storage Abstraction
     And maximum 10 files should be allowed
 
   @storage @multer @image-upload
+  @adopter
   Scenario: Image-specific upload endpoint
     When I POST to "/api/files/upload/image" with JPEG file
     Then the file should be uploaded to "images/" folder
@@ -222,6 +245,7 @@ Feature: File Storage Abstraction
     And maximum size should be 5MB
 
   @storage @multer @document-upload
+  @adopter
   Scenario: Document-specific upload endpoint
     When I POST to "/api/files/upload/document" with PDF file
     Then the file should be uploaded to "documents/" folder
@@ -229,6 +253,7 @@ Feature: File Storage Abstraction
     And maximum size should be 10MB
 
   @storage @api @download-file
+  @adopter
   Scenario: Download file via API
     Given a file exists at path "documents/report.pdf"
     When I GET "/api/files/documents/report.pdf?download=true"
@@ -236,6 +261,7 @@ Feature: File Storage Abstraction
     And Content-Disposition header should indicate attachment
 
   @storage @api @get-url
+  @adopter
   Scenario: Get file signed URL via API
     Given a file exists in storage
     When I GET "/api/files/documents/report.pdf?download=false"
@@ -243,6 +269,7 @@ Feature: File Storage Abstraction
     And no file content should be transferred
 
   @storage @api @delete-file
+  @adopter
   Scenario: Delete file via API
     Given a file exists in storage
     When I DELETE "/api/files/temp/old-file.txt"
@@ -251,6 +278,7 @@ Feature: File Storage Abstraction
     And authentication should be required
 
   @storage @api @list-files
+  @adopter
   Scenario: List files via API
     Given files exist in storage
     When I GET "/api/files/list?folder=images&maxResults=20"
@@ -258,6 +286,7 @@ Feature: File Storage Abstraction
     And pagination should be applied
 
   @storage @health-check
+  @adopter
   Scenario: Storage service health check
     When I GET "/api/files/health"
     Then health status should be returned
@@ -265,6 +294,7 @@ Feature: File Storage Abstraction
     And connectivity to storage should be verified
 
   @storage @provider-switching
+  @adopter
   Scenario: Switch storage providers
     Given STORAGE_PROVIDER is "local"
     When I change STORAGE_PROVIDER to "s3"

--- a/apps/backend/features/10-observability.feature
+++ b/apps/backend/features/10-observability.feature
@@ -8,6 +8,7 @@ Feature: Observability and Monitoring
     Given the observability repository artifacts are available
 
   @ready @metrics @prometheus @impl_prometheus_metrics
+  @template
   Scenario: Prometheus metrics exposition
     When I inspect the observability artifact "apps/backend/src/infrastructure/observability/MetricsService.ts"
     Then the observability artifact should contain:
@@ -21,6 +22,7 @@ Feature: Observability and Monitoring
       | Content-Type |
 
   @ready @metrics @custom @impl_prometheus_metrics
+  @template
   Scenario: Custom business metrics
     When I inspect the observability artifact "apps/backend/src/infrastructure/observability/MetricsService.ts"
     Then the observability artifact should contain:
@@ -30,6 +32,7 @@ Feature: Observability and Monitoring
       | incrementCounter         |
 
   @ready @metrics @labels @impl_prometheus_metrics
+  @template
   Scenario: Metrics with labels
     When I inspect the observability artifact "apps/backend/src/infrastructure/observability/MetricsService.ts"
     Then the observability artifact should contain:
@@ -39,6 +42,7 @@ Feature: Observability and Monitoring
       | status_code |
 
   @ready @grafana @impl_grafana_dashboards
+  @template
   Scenario: Grafana dashboard for metrics visualization
     When I inspect the observability artifact "kubernetes/observability/grafana/grafana-dashboards.yaml"
     Then the observability artifact should contain:
@@ -50,6 +54,7 @@ Feature: Observability and Monitoring
       | CPU Usage             |
 
   @ready @grafana @alerts @impl_grafana_alerts
+  @template
   Scenario: Grafana alerting rules
     When I inspect the observability artifact "kubernetes/observability/prometheus-rules-configmap.yaml"
     Then the observability artifact should contain:
@@ -66,6 +71,7 @@ Feature: Observability and Monitoring
       | webhook_configs   |
 
   @ready @tracing @jaeger @impl_jaeger_tracing
+  @template
   Scenario: Distributed tracing with Jaeger
     When I inspect the observability artifact "apps/backend/src/infrastructure/observability/TracingService.ts"
     Then the observability artifact should contain:
@@ -81,6 +87,7 @@ Feature: Observability and Monitoring
       | COLLECTOR_OTLP_ENABLED |
 
   @ready @tracing @spans @impl_jaeger_tracing
+  @template
   Scenario: Trace span creation
     When I inspect the observability artifact "apps/backend/src/infrastructure/observability/TracingService.ts"
     Then the observability artifact should contain:
@@ -90,6 +97,7 @@ Feature: Observability and Monitoring
       | traceExporter               |
 
   @ready @tracing @context-propagation @impl_trace_context
+  @template
   Scenario: Trace context propagation
     When I inspect the observability artifact "apps/backend/src/services/logger.service.ts"
     Then the observability artifact should contain:
@@ -100,6 +108,7 @@ Feature: Observability and Monitoring
       | TraceFlags.SAMPLED |
 
   @ready @logging @structured @impl_winston_logging
+  @template
   Scenario: Structured logging with Winston
     When I inspect the observability artifact "apps/backend/src/services/logger.service.ts"
     Then the observability artifact should contain:
@@ -111,6 +120,7 @@ Feature: Observability and Monitoring
       | format.json() |
 
   @ready @logging @levels @impl_winston_logging
+  @template
   Scenario: Log level filtering
     When I inspect the observability artifact "apps/backend/src/services/logger.service.ts"
     Then the observability artifact should contain:
@@ -127,6 +137,7 @@ Feature: Observability and Monitoring
     Then the scenario remains an adopter implementation guide
 
   @ready @logging @loki @impl_loki_logs
+  @template
   Scenario: Loki log aggregation
     When I inspect the observability artifact "kubernetes/observability/loki/loki-config.yaml"
     Then the observability artifact should contain:
@@ -140,6 +151,7 @@ Feature: Observability and Monitoring
       | kubernetes_sd_configs |
 
   @ready @apm @impl_apm_tracing
+  @template
   Scenario: Application Performance Monitoring
     When I inspect the observability artifact "apps/backend/src/infrastructure/observability/TracingService.ts"
     Then the observability artifact should contain:
@@ -153,6 +165,7 @@ Feature: Observability and Monitoring
       | db_query_duration_seconds    |
 
   @ready @health-checks @impl_readiness_check
+  @template
   Scenario: Comprehensive health check endpoints
     When I inspect the observability artifact "apps/backend/src/index.ts"
     Then the observability artifact should contain:
@@ -168,6 +181,7 @@ Feature: Observability and Monitoring
       | status: isReady         |
 
   @ready @uptime-monitoring @impl_grafana_alerts
+  @template
   Scenario: Uptime monitoring and alerting
     When I inspect the observability artifact "kubernetes/observability/prometheus-rules-configmap.yaml"
     Then the observability artifact should contain:
@@ -191,6 +205,7 @@ Feature: Observability and Monitoring
     Then the scenario remains an adopter implementation guide
 
   @ready @database-monitoring @impl_prometheus_metrics
+  @template
   Scenario: Database query performance monitoring
     When I inspect the observability artifact "apps/backend/src/infrastructure/observability/MetricsService.ts"
     Then the observability artifact should contain:
@@ -204,6 +219,7 @@ Feature: Observability and Monitoring
       | SlowDatabaseQueries |
 
   @ready @cache-monitoring @impl_prometheus_metrics
+  @template
   Scenario: Redis cache monitoring
     When I inspect the observability artifact "apps/backend/src/infrastructure/observability/MetricsService.ts"
     Then the observability artifact should contain:
@@ -216,6 +232,7 @@ Feature: Observability and Monitoring
       | HighCacheMissRate |
 
   @ready @custom-dashboards @impl_grafana_dashboards
+  @template
   Scenario: Custom monitoring dashboards
     When I inspect the observability artifact "kubernetes/observability/grafana/grafana-dashboards.yaml"
     Then the observability artifact should contain:
@@ -225,6 +242,7 @@ Feature: Observability and Monitoring
       | CPU Usage Over Time   |
 
   @ready @slo @impl_slo_monitoring
+  @template
   Scenario: Service Level Objectives tracking
     When I inspect the observability artifact "kubernetes/observability/prometheus-rules-configmap.yaml"
     Then the observability artifact should contain:
@@ -241,6 +259,7 @@ Feature: Observability and Monitoring
       | Error Budget Remaining |
 
   @ready @correlation-id @impl_trace_log_correlation
+  @template
   Scenario: Request correlation across logs and traces
     When I inspect the observability artifact "apps/backend/src/services/logger.service.ts"
     Then the observability artifact should contain:

--- a/apps/backend/features/11-advanced-testing.feature
+++ b/apps/backend/features/11-advanced-testing.feature
@@ -8,6 +8,7 @@ Feature: Advanced Testing Strategies
     Given advanced testing tools are configured
 
   @testing @bdd @cucumber
+  @adopter
   Scenario: Cucumber BDD testing
     Given Cucumber feature files are written
     When I run Cucumber tests
@@ -16,6 +17,7 @@ Feature: Advanced Testing Strategies
     And test results should be reported in Gherkin format
 
   @testing @bdd @living-documentation
+  @adopter
   Scenario: Living documentation from Cucumber
     Given Cucumber scenarios are defined
     When tests pass
@@ -24,6 +26,7 @@ Feature: Advanced Testing Strategies
     And scenarios stay in sync with implementation
 
   @ready @testing @security @owasp-zap @impl_advanced_testing_scaffold
+  @template
   Scenario: OWASP ZAP security scanning
     Given OWASP ZAP is configured
     When I run a security scan against the application
@@ -36,6 +39,7 @@ Feature: Advanced Testing Strategies
     And scan report should be generated
 
   @testing @security @dependency-scan
+  @adopter
   Scenario: Dependency vulnerability scanning
     Given dependency scanning is configured
     When I scan project dependencies
@@ -44,6 +48,7 @@ Feature: Advanced Testing Strategies
     And remediation suggestions should be provided
 
   @ready @testing @load @k6 @impl_advanced_testing_scaffold
+  @template
   Scenario: Load testing with k6
     Given k6 load test scripts are defined
     When I run load tests with 100 virtual users
@@ -53,6 +58,7 @@ Feature: Advanced Testing Strategies
     And throughput should be calculated
 
   @ready @testing @load @ramp-up @impl_advanced_testing_scaffold
+  @template
   Scenario: Gradual load ramp-up
     Given a k6 script with ramping stages
     When I run the load test
@@ -65,6 +71,7 @@ Feature: Advanced Testing Strategies
     And system behavior should be observed at each stage
 
   @ready @testing @load @thresholds @impl_advanced_testing_scaffold
+  @template
   Scenario: k6 performance thresholds
     Given performance thresholds are defined
     When load tests run
@@ -74,6 +81,7 @@ Feature: Advanced Testing Strategies
     And successful requests should be > 95%
 
   @ready @testing @contract @pact @impl_advanced_testing_scaffold
+  @template
   Scenario: Consumer-driven contract testing with Pact
     Given Pact contracts are defined
     When consumer tests run
@@ -83,6 +91,7 @@ Feature: Advanced Testing Strategies
     And compatibility should be ensured
 
   @ready @testing @contract @breaking-changes @impl_advanced_testing_scaffold
+  @template
   Scenario: Contract breaking change detection
     Given a Pact contract exists between consumer and provider
     When provider changes API in incompatible way
@@ -91,6 +100,7 @@ Feature: Advanced Testing Strategies
     And deployment should be blocked
 
   @testing @visual-regression
+  @adopter
   Scenario: Visual regression testing
     Given baseline screenshots exist
     When I run visual regression tests
@@ -99,6 +109,7 @@ Feature: Advanced Testing Strategies
     And tests should fail if differences exceed threshold
 
   @testing @accessibility @axe
+  @adopter
   Scenario: Automated accessibility testing with axe-core
     Given axe-core is integrated in tests
     When I test a page for accessibility
@@ -107,6 +118,7 @@ Feature: Advanced Testing Strategies
     And remediation guidance should be provided
 
   @testing @mutation
+  @adopter
   Scenario: Mutation testing for test quality
     Given mutation testing is configured
     When I run mutation tests
@@ -115,6 +127,7 @@ Feature: Advanced Testing Strategies
     And mutation score should indicate test quality
 
   @testing @smoke
+  @adopter
   Scenario: Smoke test suite for quick validation
     Given smoke tests are defined
     When I run smoke tests
@@ -124,6 +137,7 @@ Feature: Advanced Testing Strategies
 
   @publishing @registry @impl_publish_flow
   @ready
+  @template
   Scenario: Registry-agnostic publish flow is wired
     Given a registry-agnostic publish script exists
     And an npmrc template exists for local publishing
@@ -133,6 +147,7 @@ Feature: Advanced Testing Strategies
 
   @database @prisma @migrations @impl_prisma7_migration_workaround
   @ready
+  @template
   Scenario: Prisma 7 CLI migration workaround is documented and wired
     Given Prisma CLI configuration is maintained at the monorepo root
     And the backend Prisma schema should not embed a datasource URL
@@ -142,6 +157,7 @@ Feature: Advanced Testing Strategies
     And ADR-010 should document the Prisma 7 migration workaround
 
   @testing @regression
+  @adopter
   Scenario: Regression test suite
     Given regression tests cover existing features
     When new code is deployed
@@ -150,6 +166,7 @@ Feature: Advanced Testing Strategies
     And no regressions should be introduced
 
   @testing @chaos
+  @adopter
   Scenario: Chaos engineering experiments
     Given chaos engineering tools are configured
     When I inject failures randomly
@@ -158,6 +175,7 @@ Feature: Advanced Testing Strategies
     And weak points should be identified
 
   @testing @monkey
+  @adopter
   Scenario: Monkey testing for unexpected inputs
     Given monkey testing is configured
     When random actions are performed on UI
@@ -166,6 +184,7 @@ Feature: Advanced Testing Strategies
     And unexpected behavior should be logged
 
   @testing @property-based
+  @adopter
   Scenario: Property-based testing
     Given property-based tests are defined
     When tests run with generated inputs
@@ -174,6 +193,7 @@ Feature: Advanced Testing Strategies
     And counterexamples should be minimized
 
   @testing @snapshot @approval
+  @adopter
   Scenario: Approval testing for complex outputs
     Given approval tests are configured
     When complex output is generated
@@ -182,6 +202,7 @@ Feature: Advanced Testing Strategies
     Then developers should review and approve changes
 
   @testing @test-data @factory
+  @adopter
   Scenario: Test data factories
     Given test data factories are defined
     When tests need sample data
@@ -190,6 +211,7 @@ Feature: Advanced Testing Strategies
     And related data should be consistent
 
   @testing @parallel @distributed
+  @adopter
   Scenario: Distributed parallel test execution
     Given tests can run in parallel
     When I run tests across multiple machines
@@ -198,6 +220,7 @@ Feature: Advanced Testing Strategies
     And total execution time should be reduced
 
   @testing @flaky-detection
+  @adopter
   Scenario: Flaky test detection and management
     Given flaky test detection is enabled
     When a test fails intermittently

--- a/apps/backend/features/12-kubernetes-devops.feature
+++ b/apps/backend/features/12-kubernetes-devops.feature
@@ -9,6 +9,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And DevOps tools are configured
 
   @ready @k8s @deployment @impl_k8s_app_manifests
+  @template
   Scenario: Kubernetes deployment manifest
     Given a Kubernetes deployment manifest exists
     When I apply the deployment
@@ -17,6 +18,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And containers should be running
 
   @ready @k8s @service @impl_k8s_app_manifests
+  @template
   Scenario: Kubernetes service for load balancing
     Given a Kubernetes service is defined
     When the service is created
@@ -25,6 +27,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And service discovery should work
 
   @k8s @ingress
+  @adopter
   Scenario: Ingress controller for external access
     Given an Ingress resource is configured
     When I access the application via domain
@@ -33,6 +36,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And HTTP to HTTPS redirect should work
 
   @ready @k8s @configmap @impl_k8s_app_manifests
+  @template
   Scenario: ConfigMap for configuration management
     Given a ConfigMap with application config
     When pods are deployed
@@ -42,6 +46,7 @@ Feature: Kubernetes and DevOps Infrastructure
     Then pods should be restarted with new config
 
   @k8s @secrets
+  @adopter
   Scenario: Kubernetes Secrets for sensitive data
     Given secrets are stored in Kubernetes Secrets
     When pods are deployed
@@ -50,6 +55,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And secrets should be encrypted at rest
 
   @k8s @hpa
+  @adopter
   Scenario: Horizontal Pod Autoscaler
     Given HPA is configured for the deployment
     And target CPU utilization is 70%
@@ -59,6 +65,7 @@ Feature: Kubernetes and DevOps Infrastructure
     Then excess pods should be terminated
 
   @k8s @vpa
+  @adopter
   Scenario: Vertical Pod Autoscaler
     Given VPA is configured
     When pod resource usage is monitored
@@ -66,6 +73,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And pods should be updated with new limits
 
   @ready @k8s @resource-limits @impl_k8s_app_manifests
+  @template
   Scenario: Resource requests and limits
     Given pods have resource limits defined
     Then each pod should have:
@@ -76,6 +84,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And resource requests should be guaranteed
 
   @ready @k8s @health-probes @impl_k8s_app_manifests
+  @template
   Scenario: Liveness and readiness probes
     Given health probes are configured
     When a pod starts
@@ -84,6 +93,7 @@ Feature: Kubernetes and DevOps Infrastructure
     Then liveness probe should restart the pod
 
   @k8s @rolling-update
+  @adopter
   Scenario: Rolling update deployment strategy
     Given a new version is ready to deploy
     When I update the deployment
@@ -92,6 +102,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And zero downtime should be achieved
 
   @k8s @rollback
+  @adopter
   Scenario: Deployment rollback
     Given a new deployment caused issues
     When I rollback the deployment
@@ -100,6 +111,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And service should return to normal
 
   @k8s @persistent-volume
+  @adopter
   Scenario: Persistent Volume for stateful data
     Given a PersistentVolumeClaim is defined
     When a pod mounts the PVC
@@ -107,6 +119,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And volume should be provisioned dynamically
 
   @k8s @statefulset
+  @adopter
   Scenario: StatefulSet for stateful applications
     Given a StatefulSet is configured for database
     When StatefulSet is deployed
@@ -115,6 +128,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And pods should be created/deleted in order
 
   @k8s @network-policy
+  @adopter
   Scenario: Network policies for pod communication
     Given NetworkPolicies are defined
     Then pod-to-pod communication should be restricted
@@ -122,6 +136,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And unauthorized traffic should be blocked
 
   @k8s @monitoring
+  @adopter
   Scenario: Kubernetes metrics with Prometheus
     Given Prometheus is deployed in cluster
     When I query Kubernetes metrics
@@ -130,6 +145,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And cluster metrics should be available
 
   @cicd @github-actions
+  @adopter
   Scenario: GitHub Actions CI/CD pipeline
     Given GitHub Actions workflow is configured
     When I push code to repository
@@ -142,6 +158,7 @@ Feature: Kubernetes and DevOps Infrastructure
 
   @cicd @github-actions @impl_workflow_lint_actionlint
   @ready
+  @template
   Scenario: Workflow linting is wired with actionlint
     Given workflow lint tooling is present
     Then root package.json should expose a workflows lint command
@@ -150,6 +167,7 @@ Feature: Kubernetes and DevOps Infrastructure
 
   @cicd @build @impl_docker_multistage_build
   @ready
+  @template
   Scenario: Multi-stage Docker build
     Given a multi-stage Dockerfile exists
     When I build the Docker image
@@ -159,6 +177,7 @@ Feature: Kubernetes and DevOps Infrastructure
 
   @k8s @verdaccio @impl_verdaccio_k8s_manifests
   @ready
+  @template
   Scenario: Verdaccio in-cluster registry manifests are present
     Given Verdaccio Kubernetes manifests are available
     Then Verdaccio manifests should include a Deployment, Service, PVC, and ConfigMap
@@ -167,6 +186,7 @@ Feature: Kubernetes and DevOps Infrastructure
 
   @docker @compose @impl_docker_compose_dev
   @ready
+  @template
   Scenario: Docker Compose development environment is configured
     Given Docker Compose configuration exists
     Then the Compose file should define required services
@@ -174,6 +194,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And frontend service should build from the frontend Dockerfile
 
   @ready @cicd @test-stage @impl_ci_test_stage
+  @template
   Scenario: CI pipeline test stage
     Given CI pipeline has test stage
     When tests run in CI
@@ -183,6 +204,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And test results should be published
 
   @cicd @security-scan
+  @adopter
   Scenario: Container security scanning
     Given security scanning is enabled in CI
     When Docker image is built
@@ -191,6 +213,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And scan report should be archived
 
   @cicd @deploy-staging
+  @adopter
   Scenario: Automated deployment to staging
     Given tests pass in CI
     When deployment stage runs
@@ -199,6 +222,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And staging should be validated
 
   @cicd @deploy-production
+  @adopter
   Scenario: Production deployment with approval
     Given staging deployment succeeded
     When production deployment is triggered
@@ -208,6 +232,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And health checks should verify deployment
 
   @cicd @canary-deployment
+  @adopter
   Scenario: Canary deployment strategy - healthy metrics
     Given canary deployment is configured
     When new version is deployed
@@ -217,6 +242,7 @@ Feature: Kubernetes and DevOps Infrastructure
     Then traffic should gradually shift to 100%
 
   @cicd @canary-deployment
+  @adopter
   Scenario: Canary deployment strategy - unhealthy metrics
     Given canary deployment is configured
     When new version is deployed
@@ -226,6 +252,7 @@ Feature: Kubernetes and DevOps Infrastructure
     Then rollback should occur
 
   @cicd @blue-green
+  @adopter
   Scenario: Blue-green deployment
     Given blue environment is running
     When green environment is deployed
@@ -236,6 +263,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And blue should be kept for rollback
 
   @cicd @gitops
+  @adopter
   Scenario: GitOps with ArgoCD/FluxCD
     Given GitOps is configured
     When I commit to Git repository
@@ -244,6 +272,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And deployments should be automated
 
   @cicd @secrets-management
+  @adopter
   Scenario: Secrets management in CI/CD
     Given secrets are stored in vault
     When CI/CD pipeline runs
@@ -252,6 +281,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And secrets should be rotated regularly
 
   @cicd @notifications
+  @adopter
   Scenario: Build and deployment notifications
     Given notification integrations are configured
     When build fails
@@ -262,6 +292,7 @@ Feature: Kubernetes and DevOps Infrastructure
     Then on-call engineer should be paged
 
   @k8s @service-mesh
+  @adopter
   Scenario: Service mesh with Istio/Linkerd
     Given service mesh is deployed
     When services communicate
@@ -271,6 +302,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And retries should be automatic
 
   @k8s @operator
+  @adopter
   Scenario: Kubernetes operator for custom resources
     Given a custom operator is deployed
     When I create a custom resource
@@ -279,6 +311,7 @@ Feature: Kubernetes and DevOps Infrastructure
     And operator should handle updates
 
   @k8s @backup
+  @adopter
   Scenario: Cluster backup and restore
     Given backup solution is configured
     When backup is triggered
@@ -288,6 +321,7 @@ Feature: Kubernetes and DevOps Infrastructure
     Then cluster should be restorable from backup
 
   @k8s @cost-optimization
+  @adopter
   Scenario: Resource cost monitoring
     Given cost monitoring is enabled
     When I view cost reports

--- a/apps/backend/features/13-message-queue.feature
+++ b/apps/backend/features/13-message-queue.feature
@@ -10,6 +10,7 @@ Feature: Message Queue System with BullMQ
     And Bull Board dashboard is configured
 
   @ready @queue @email @impl_queue_system
+  @template
   Scenario: Queue email notification job
     Given email queue is configured
     When I add an email job with recipient "user@example.com"
@@ -18,6 +19,7 @@ Feature: Message Queue System with BullMQ
     And the job should be visible in Bull Board dashboard
 
   @ready @queue @email @processing @impl_queue_system
+  @template
   Scenario: Process email job successfully
     Given email queue has a pending job
     When the EmailProcessor processes the job
@@ -26,6 +28,7 @@ Feature: Message Queue System with BullMQ
     And completion time should be recorded
 
   @ready @queue @email @retry @impl_queue_system
+  @template
   Scenario: Retry failed email job
     Given email queue has a failing job
     And retry strategy is configured with 3 attempts
@@ -35,6 +38,7 @@ Feature: Message Queue System with BullMQ
     And backoff delay should be exponential
 
   @ready @queue @sms @impl_queue_system
+  @template
   Scenario: Queue SMS notification job
     Given SMS queue is configured
     When I add an SMS job with phone "+1234567890"
@@ -42,6 +46,7 @@ Feature: Message Queue System with BullMQ
     And the job should respect rate limits
 
   @ready @queue @webhook @impl_queue_system
+  @template
   Scenario: Queue webhook delivery job
     Given webhook queue is configured
     When I add a webhook job with URL "https://api.example.com/webhook"
@@ -49,6 +54,7 @@ Feature: Message Queue System with BullMQ
     And the job should include payload and headers
 
   @ready @queue @file-processing @impl_queue_system
+  @template
   Scenario: Queue file processing job
     Given file-processing queue is configured
     When I add a file processing job for "document.pdf"
@@ -56,11 +62,13 @@ Feature: Message Queue System with BullMQ
     And the job should include file metadata
 
   @ready @queue @monitoring @impl_queue_system
+  @template
   Scenario: Bull Board dashboard route is configured
     Given Bull Board dashboard is configured
     Then the queue monitoring dashboard should be available at "/admin/queues"
 
   @ready @queue @monitoring @impl_queue_system
+  @template
   Scenario: View queue metrics in Bull Board
     Given Bull Board dashboard is enabled
     And queues have active and completed jobs
@@ -70,6 +78,7 @@ Feature: Message Queue System with BullMQ
     And I should see active, completed, and failed jobs
 
   @ready @queue @health @impl_queue_system
+  @template
   Scenario: Queue health participates in readiness checks
     Given queue health check is configured
     When the readiness endpoint checks dependencies
@@ -77,6 +86,7 @@ Feature: Message Queue System with BullMQ
     And disabled queues should be reported as "disabled"
 
   @queue @management
+  @adopter
   Scenario: Pause and resume queue
     Given email queue is active
     When I pause the email queue
@@ -86,6 +96,7 @@ Feature: Message Queue System with BullMQ
     Then jobs should start processing again
 
   @queue @management
+  @adopter
   Scenario: Clean completed jobs
     Given email queue has 100 completed jobs
     When I clean completed jobs older than 24 hours
@@ -93,6 +104,7 @@ Feature: Message Queue System with BullMQ
     And recent completed jobs should remain
 
   @queue @management
+  @adopter
   Scenario: Drain queue
     Given email queue has pending jobs
     When I drain the email queue
@@ -100,6 +112,7 @@ Feature: Message Queue System with BullMQ
     And active jobs should complete normally
 
   @queue @rate-limiting
+  @adopter
   Scenario: Respect concurrency limits
     Given email queue has concurrency limit of 5
     When 10 jobs are queued simultaneously
@@ -107,6 +120,7 @@ Feature: Message Queue System with BullMQ
     And remaining jobs should wait in queue
 
   @queue @rate-limiting
+  @adopter
   Scenario: Respect rate limits per minute
     Given webhook queue has rate limit of 100 jobs/minute
     When 150 jobs are queued in one minute
@@ -114,6 +128,7 @@ Feature: Message Queue System with BullMQ
     And 50 jobs should process in second minute
 
   @ready @queue @error-handling @dlq @impl_queue_system
+  @template
   Scenario: Handle processor errors gracefully
     Given email queue has a job
     And EmailProcessor throws an error
@@ -123,6 +138,7 @@ Feature: Message Queue System with BullMQ
     And retry should be attempted if configured
 
   @queue @integration
+  @adopter
   Scenario: Queue system integrates with NotificationService
     Given NotificationService is configured
     And QueueService is available
@@ -131,6 +147,7 @@ Feature: Message Queue System with BullMQ
     And fallback to direct send if queue unavailable
 
   @queue @data-export
+  @adopter
   Scenario: Queue data export job
     Given data-export queue is configured
     When I request a CSV export of user data
@@ -139,6 +156,7 @@ Feature: Message Queue System with BullMQ
     And progress should be tracked
 
   @queue @cleanup
+  @adopter
   Scenario: Queue cleanup job
     Given cleanup queue is configured
     When I schedule a cleanup job for expired sessions
@@ -146,6 +164,7 @@ Feature: Message Queue System with BullMQ
     And the job should execute at specified time
 
   @queue @priority
+  @adopter
   Scenario: Process high-priority jobs first
     Given email queue has jobs with different priorities
     When I add a high-priority job

--- a/apps/backend/features/14-websocket.feature
+++ b/apps/backend/features/14-websocket.feature
@@ -10,6 +10,7 @@ Feature: WebSocket Real-Time Communication
     And authentication middleware is active
 
   @websocket @ready @impl_websocket_support
+  @template
   Scenario: WebSocket service wiring is configured
     Given the backend WebSocket service is implemented
     Then WebSockets should be gated by "DISABLE_WEBSOCKETS"
@@ -17,6 +18,7 @@ Feature: WebSocket Real-Time Communication
     And WebSocket service should default to path "/socket.io"
 
   @websocket @connection
+  @adopter
   Scenario: Client connects with valid token
     Given I have a valid authentication token
     When I connect to WebSocket server with token
@@ -25,6 +27,7 @@ Feature: WebSocket Real-Time Communication
     And my connection should be tracked in server
 
   @ready @websocket @connection @auth @impl_websocket_auth_rejection
+  @template
   Scenario: Client connection rejected without token
     Given I do not have an authentication token
     When I attempt to connect to WebSocket server
@@ -33,6 +36,7 @@ Feature: WebSocket Real-Time Communication
     And connection count should not increase
 
   @ready @websocket @connection @impl_websocket_disconnect_tracking
+  @template
   Scenario: Client disconnects gracefully
     Given I am connected to WebSocket server
     When I disconnect from the server
@@ -41,6 +45,7 @@ Feature: WebSocket Real-Time Communication
     And disconnect event should be logged
 
   @ready @websocket @rooms @impl_websocket_rooms
+  @template
   Scenario: Client joins a room
     Given I am connected to WebSocket server
     When I request to join room "project-123"
@@ -50,6 +55,7 @@ Feature: WebSocket Real-Time Communication
     And room member count should increase
 
   @ready @websocket @rooms @impl_websocket_rooms
+  @template
   Scenario: Client leaves a room
     Given I am connected to WebSocket server
     And I have joined room "project-123"
@@ -60,6 +66,7 @@ Feature: WebSocket Real-Time Communication
     And room member count should decrease
 
   @ready @websocket @rooms @impl_websocket_room_info
+  @template
   Scenario: Get room information
     Given multiple clients are connected to WebSocket server
     And 5 clients have joined room "team-chat"
@@ -69,6 +76,7 @@ Feature: WebSocket Real-Time Communication
     And room name should be "team-chat"
 
   @ready @websocket @messaging @impl_websocket_room_messages
+  @template
   Scenario: Send message to room
     Given I am connected to WebSocket server
     And I have joined room "project-123"
@@ -79,6 +87,7 @@ Feature: WebSocket Real-Time Communication
     And the message should have a timestamp
 
   @websocket @messaging
+  @adopter
   Scenario: Send direct message to user
     Given I am connected to WebSocket server
     And user "user-456" is also connected
@@ -88,6 +97,7 @@ Feature: WebSocket Real-Time Communication
     And other clients should not receive the message
 
   @ready @websocket @typing @impl_websocket_typing
+  @template
   Scenario: Broadcast typing indicator
     Given I am connected to WebSocket server
     And I have joined room "chat-room"
@@ -97,6 +107,7 @@ Feature: WebSocket Real-Time Communication
     And the event should include the room ID
 
   @ready @websocket @typing @impl_websocket_typing
+  @template
   Scenario: Stop typing indicator
     Given I am connected to WebSocket server
     And I have joined room "chat-room"
@@ -106,6 +117,7 @@ Feature: WebSocket Real-Time Communication
     And my typing indicator should be cleared
 
   @ready @websocket @presence @impl_websocket_presence
+  @template
   Scenario: Update user presence status
     Given I am connected to WebSocket server
     When I update my presence to "away"
@@ -114,6 +126,7 @@ Feature: WebSocket Real-Time Communication
     And the update should include timestamp
 
   @ready @websocket @presence @impl_websocket_presence_statuses
+  @template
   Scenario: Presence statuses
     Given I am connected to WebSocket server
     Then I can set presence to "online"
@@ -122,6 +135,7 @@ Feature: WebSocket Real-Time Communication
     And I can set presence to "offline"
 
   @ready @websocket @broadcasting @impl_websocket_broadcast
+  @template
   Scenario: Broadcast to all connected clients
     Given multiple clients are connected to WebSocket server
     When server broadcasts a system announcement
@@ -130,6 +144,7 @@ Feature: WebSocket Real-Time Communication
     And the message should include system sender
 
   @ready @websocket @broadcasting @impl_websocket_broadcast_room
+  @template
   Scenario: Broadcast to specific room only
     Given I am connected to WebSocket server
     And room "team-a" has 5 clients
@@ -139,6 +154,7 @@ Feature: WebSocket Real-Time Communication
     And clients in "team-b" should not receive the message
 
   @websocket @scaling
+  @adopter
   Scenario: Horizontal scaling with Redis adapter
     Given Redis Pub/Sub is configured
     And multiple WebSocket server instances are running
@@ -149,6 +165,7 @@ Feature: WebSocket Real-Time Communication
     And Redis should handle message distribution
 
   @websocket @rate-limiting
+  @adopter
   Scenario: Connection rate limiting
     Given max connections limit is 1000
     When 1001 clients attempt to connect
@@ -157,6 +174,7 @@ Feature: WebSocket Real-Time Communication
     And rate limit error should be returned
 
   @websocket @rate-limiting
+  @adopter
   Scenario: Event rate limiting per client
     Given I am connected to WebSocket server
     And event throttling is enabled
@@ -166,6 +184,7 @@ Feature: WebSocket Real-Time Communication
     And rate limit warning should be issued
 
   @ready @websocket @health @impl_websocket_health
+  @template
   Scenario: WebSocket health check
     Given WebSocket server is running
     When health check is requested
@@ -175,6 +194,7 @@ Feature: WebSocket Real-Time Communication
     And Redis adapter status should be included
 
   @ready @websocket @health @metrics @impl_websocket_metrics
+  @template
   Scenario: WebSocket metrics
     Given WebSocket server is running
     And multiple clients are connected
@@ -185,6 +205,7 @@ Feature: WebSocket Real-Time Communication
     And uptime should be included
 
   @websocket @error-handling
+  @adopter
   Scenario: Handle invalid event data
     Given I am connected to WebSocket server
     When I send malformed event data
@@ -193,6 +214,7 @@ Feature: WebSocket Real-Time Communication
     And my connection should remain active
 
   @websocket @error-handling
+  @adopter
   Scenario: Handle room join timeout
     Given I am connected to WebSocket server
     When I request to join a room
@@ -201,6 +223,7 @@ Feature: WebSocket Real-Time Communication
     And the join request should be cancelled
 
   @websocket @security
+  @adopter
   Scenario: Token expiration during connection
     Given I am connected with a token expiring in 1 minute
     When my token expires
@@ -209,6 +232,7 @@ Feature: WebSocket Real-Time Communication
     And I should be able to reconnect with new token
 
   @websocket @security
+  @adopter
   Scenario: Prevent unauthorized room access
     Given I am connected to WebSocket server
     And room "private-channel" requires special permissions
@@ -217,6 +241,7 @@ Feature: WebSocket Real-Time Communication
     And I should receive permission error
 
   @websocket @integration
+  @adopter
   Scenario: WebSocket integrates with HTTP server
     Given backend HTTP server is running
     And WebSocket service is initialized
@@ -225,6 +250,7 @@ Feature: WebSocket Real-Time Communication
     And both HTTP and WebSocket should be operational
 
   @ready @websocket @shutdown @impl_websocket_shutdown
+  @template
   Scenario: Graceful shutdown
     Given WebSocket server is running
     And multiple clients are connected
@@ -235,6 +261,7 @@ Feature: WebSocket Real-Time Communication
     And no data should be lost
 
   @ready @websocket @frontend @impl_frontend_websocket_hook
+  @template
   Scenario: React hook manages connection state
     Given I use useWebSocket hook in frontend
     When component mounts
@@ -244,6 +271,7 @@ Feature: WebSocket Real-Time Communication
     Then WebSocket should disconnect cleanly
 
   @ready @websocket @frontend @impl_frontend_websocket_reconnect
+  @template
   Scenario: Auto-reconnection after disconnect
     Given I am connected via useWebSocket hook
     When connection is lost unexpectedly

--- a/apps/backend/features/observability/metrics.feature
+++ b/apps/backend/features/observability/metrics.feature
@@ -1,3 +1,4 @@
+@template
 @ready @observability
 Feature: Prometheus Metrics Collection
   As a DevOps engineer

--- a/apps/backend/src/utils/bdd-governance.spec.ts
+++ b/apps/backend/src/utils/bdd-governance.spec.ts
@@ -9,6 +9,8 @@ describe('unit: computeBddGovernanceSnapshot', () => {
     expect(snapshot).toHaveProperty('generatedAt');
     expect(snapshot).toHaveProperty('overall');
     expect(snapshot.overall).toHaveProperty('total');
+    expect(snapshot.responsibility.total).toBe(snapshot.overall.total);
+    expect(snapshot.responsibility.other).toBe(0);
 
     expect(snapshot).toHaveProperty('apps');
     expect(Array.isArray(snapshot.apps)).toBe(true);
@@ -19,6 +21,8 @@ describe('unit: computeBddGovernanceSnapshot', () => {
     expect(snapshot).toHaveProperty('issues');
     expect(snapshot.issues).toHaveProperty('missingStatus');
     expect(snapshot.issues).toHaveProperty('conflictingStatus');
+    expect(snapshot.issues.missingResponsibility).toHaveLength(0);
+    expect(snapshot.issues.conflictingResponsibility).toHaveLength(0);
 
     expect(snapshot).toHaveProperty('implAudit');
     expect(snapshot.implAudit).toHaveProperty('implTags');

--- a/apps/backend/src/utils/bdd-governance.ts
+++ b/apps/backend/src/utils/bdd-governance.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 type StatusKey = 'ready' | 'wip' | 'manual' | 'skip' | 'other';
+export type ResponsibilityKey = 'template' | 'adopter' | 'other';
 
 export type StatusCounts = {
   total: number;
@@ -9,6 +10,13 @@ export type StatusCounts = {
   wip: number;
   manual: number;
   skip: number;
+  other: number;
+};
+
+export type ResponsibilityCounts = {
+  total: number;
+  template: number;
+  adopter: number;
   other: number;
 };
 
@@ -46,6 +54,7 @@ export type BddScenarioOverview = {
   featureName: string;
   scenarioName: string;
   status: StatusKey;
+  responsibility: ResponsibilityKey;
   tags: string[];
   implTags: string[];
 };
@@ -64,9 +73,12 @@ export type BddGovernanceSnapshot = {
   apps: Array<{ appName: string; counts: StatusCounts }>;
   features: BddFeatureOverview[];
   overall: StatusCounts;
+  responsibility: ResponsibilityCounts;
   issues: {
     missingStatus: MissingStatusIssue[];
     conflictingStatus: ConflictingStatusIssue[];
+    missingResponsibility: MissingStatusIssue[];
+    conflictingResponsibility: ConflictingStatusIssue[];
   };
   implAudit: {
     implTagsTotal: number;
@@ -89,15 +101,20 @@ const PRIMARY_STATUS_TAGS: readonly string[] = [
   STATUS_TAGS.manual,
 ];
 
+const RESPONSIBILITY_TAGS: readonly string[] = ['@template', '@adopter'];
+
 type ScenarioRow = {
   filePath: string;
   featureName: string;
   scenarioName: string;
   tags: string[];
   status: StatusKey;
+  responsibility: ResponsibilityKey;
   implTags: string[];
   featurePrimaryStatusTags: string[];
   scenarioPrimaryStatusTags: string[];
+  featureResponsibilityTags: string[];
+  scenarioResponsibilityTags: string[];
 };
 
 type FeatureRow = {
@@ -110,6 +127,10 @@ type FeatureRow = {
 
 function createEmptyCounts(): StatusCounts {
   return { total: 0, ready: 0, wip: 0, manual: 0, skip: 0, other: 0 };
+}
+
+function createEmptyResponsibilityCounts(): ResponsibilityCounts {
+  return { total: 0, template: 0, adopter: 0, other: 0 };
 }
 
 function parseTagsLine(line: string): string[] {
@@ -136,6 +157,12 @@ function classify(tags: string[]): StatusKey {
   if (tags.includes(STATUS_TAGS.manual)) return 'manual';
   if (tags.includes(STATUS_TAGS.ready)) return 'ready';
   if (tags.includes(STATUS_TAGS.wip)) return 'wip';
+  return 'other';
+}
+
+function classifyResponsibility(tags: string[]): ResponsibilityKey {
+  if (tags.includes('@template')) return 'template';
+  if (tags.includes('@adopter')) return 'adopter';
   return 'other';
 }
 
@@ -274,11 +301,23 @@ function parseFeatureFile(appName: string, filePath: string, content: string): F
       const effectivePrimaryStatusTags =
         scenarioPrimaryStatusTags.length > 0 ? scenarioPrimaryStatusTags : featurePrimaryStatusTags;
 
+      const featureResponsibilityTags = RESPONSIBILITY_TAGS.filter((t) => featureTags.includes(t));
+      const scenarioResponsibilityTags = RESPONSIBILITY_TAGS.filter((t) => pendingTags.includes(t));
+      const effectiveResponsibilityTags =
+        scenarioResponsibilityTags.length > 0
+          ? scenarioResponsibilityTags
+          : featureResponsibilityTags;
+
       const tags = Array.from(
         new Set([
-          ...featureTags.filter((t) => !PRIMARY_STATUS_TAGS.includes(t)),
-          ...pendingTags.filter((t) => !PRIMARY_STATUS_TAGS.includes(t)),
+          ...featureTags.filter(
+            (t) => !PRIMARY_STATUS_TAGS.includes(t) && !RESPONSIBILITY_TAGS.includes(t)
+          ),
+          ...pendingTags.filter(
+            (t) => !PRIMARY_STATUS_TAGS.includes(t) && !RESPONSIBILITY_TAGS.includes(t)
+          ),
           ...effectivePrimaryStatusTags,
+          ...effectiveResponsibilityTags,
         ])
       );
 
@@ -288,9 +327,12 @@ function parseFeatureFile(appName: string, filePath: string, content: string): F
         scenarioName,
         tags,
         status: classify(tags),
+        responsibility: classifyResponsibility(tags),
         implTags: extractImplTags(tags),
         featurePrimaryStatusTags,
         scenarioPrimaryStatusTags,
+        featureResponsibilityTags,
+        scenarioResponsibilityTags,
       });
 
       pendingTags = [];
@@ -307,6 +349,27 @@ function parseFeatureFile(appName: string, filePath: string, content: string): F
     featureTags,
     scenarios,
   };
+}
+
+function evaluateResponsibilityIssues(
+  row: ScenarioRow,
+  missing: MissingStatusIssue[],
+  conflicting: ConflictingStatusIssue[]
+): void {
+  const effective =
+    row.scenarioResponsibilityTags.length > 0
+      ? row.scenarioResponsibilityTags
+      : row.featureResponsibilityTags;
+  if (effective.length === 0) {
+    missing.push({ filePath: row.filePath, scenarioName: row.scenarioName, tags: row.tags });
+  } else if (effective.length > 1) {
+    conflicting.push({
+      filePath: row.filePath,
+      scenarioName: row.scenarioName,
+      tags: row.tags,
+      primaryStatusTags: effective,
+    });
+  }
 }
 
 function evaluateStatusIssues(
@@ -381,6 +444,14 @@ function incrementCounts(counts: StatusCounts, status: StatusKey): void {
   }
 }
 
+function incrementResponsibilityCounts(
+  counts: ResponsibilityCounts,
+  responsibility: ResponsibilityKey
+): void {
+  counts.total += 1;
+  counts[responsibility] += 1;
+}
+
 function addImplRow(implMap: Map<string, ImplSummary>, implTag: string, row: ScenarioRow): void {
   if (!implMap.has(implTag)) {
     implMap.set(implTag, { ready: 0, wip: 0, manual: 0, skip: 0, other: 0, scenarios: [] });
@@ -400,6 +471,9 @@ type ComputeAppCountsParams = {
   implMap: Map<string, ImplSummary>;
   missingReadyImpl: Array<{ filePath: string; scenarioName: string }>;
   overall: StatusCounts;
+  responsibility: ResponsibilityCounts;
+  missingResponsibility: MissingStatusIssue[];
+  conflictingResponsibility: ConflictingStatusIssue[];
 };
 
 function computeAppCounts(params: ComputeAppCountsParams): StatusCounts | null {
@@ -412,6 +486,9 @@ function computeAppCounts(params: ComputeAppCountsParams): StatusCounts | null {
     implMap,
     missingReadyImpl,
     overall,
+    responsibility,
+    missingResponsibility,
+    conflictingResponsibility,
   } = params;
   const appCounts = createEmptyCounts();
   const featureFiles = findFeatureFiles(featuresDir);
@@ -426,9 +503,11 @@ function computeAppCounts(params: ComputeAppCountsParams): StatusCounts | null {
 
     for (const row of feature.scenarios) {
       evaluateStatusIssues(row, outMissingStatus, outConflictingStatus);
+      evaluateResponsibilityIssues(row, missingResponsibility, conflictingResponsibility);
 
       incrementCounts(appCounts, row.status);
       incrementCounts(overall, row.status);
+      incrementResponsibilityCounts(responsibility, row.responsibility);
 
       if (row.status === 'ready' && row.implTags.length === 0) {
         missingReadyImpl.push({ filePath: row.filePath, scenarioName: row.scenarioName });
@@ -450,9 +529,12 @@ export function computeBddGovernanceSnapshot(): BddGovernanceSnapshot {
   const apps: Array<{ appName: string; counts: StatusCounts }> = [];
   const features: FeatureRow[] = [];
   const overall = createEmptyCounts();
+  const responsibility = createEmptyResponsibilityCounts();
 
   const missingStatus: MissingStatusIssue[] = [];
   const conflictingStatus: ConflictingStatusIssue[] = [];
+  const missingResponsibility: MissingStatusIssue[] = [];
+  const conflictingResponsibility: ConflictingStatusIssue[] = [];
 
   const implMap = new Map<string, ImplSummary>();
   const missingReadyImpl: Array<{ filePath: string; scenarioName: string }> = [];
@@ -474,6 +556,9 @@ export function computeBddGovernanceSnapshot(): BddGovernanceSnapshot {
       implMap,
       missingReadyImpl,
       overall,
+      responsibility,
+      missingResponsibility,
+      conflictingResponsibility,
     });
 
     if (!appCounts) continue;
@@ -512,15 +597,25 @@ export function computeBddGovernanceSnapshot(): BddGovernanceSnapshot {
             featureName: s.featureName,
             scenarioName: s.scenarioName,
             status: s.status,
+            responsibility: s.responsibility,
             tags: s.tags,
             implTags: s.implTags,
           })),
         };
       }),
     overall,
+    responsibility,
     issues: {
       missingStatus: missingStatus.map((i) => ({ ...i, filePath: relify(repoRoot, i.filePath) })),
       conflictingStatus: conflictingStatus.map((i) => ({
+        ...i,
+        filePath: relify(repoRoot, i.filePath),
+      })),
+      missingResponsibility: missingResponsibility.map((i) => ({
+        ...i,
+        filePath: relify(repoRoot, i.filePath),
+      })),
+      conflictingResponsibility: conflictingResponsibility.map((i) => ({
         ...i,
         filePath: relify(repoRoot, i.filePath),
       })),

--- a/apps/frontend/app/dashboard/bdd/BddFeatureScenarioOverview.tsx
+++ b/apps/frontend/app/dashboard/bdd/BddFeatureScenarioOverview.tsx
@@ -4,10 +4,11 @@ import type { Route } from 'next';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState, type JSX } from 'react';
 
-import type { BddFeatureOverview, StatusKey } from './types';
+import type { BddFeatureOverview, ResponsibilityKey, StatusKey } from './types';
 
 const STATUS_ORDER: readonly StatusKey[] = ['ready', 'wip', 'manual', 'skip', 'other'];
 const STATUS_SET_ALL = new Set<StatusKey>(STATUS_ORDER);
+const RESPONSIBILITY_ORDER: readonly ResponsibilityKey[] = ['template', 'adopter', 'other'];
 
 function isStatusKey(v: string): v is StatusKey {
   return (STATUS_ORDER as readonly string[]).includes(v);
@@ -46,6 +47,21 @@ function serializeStatesParam(selected: Set<StatusKey>): string | undefined {
   if (selected.size === 0) return 'none';
   if (isAllSelected(selected)) return undefined;
   return STATUS_ORDER.filter((s) => selected.has(s)).join(',');
+}
+
+function parseScopesParam(param: string | undefined): Set<ResponsibilityKey> {
+  if (param === undefined) return new Set(['template']);
+  if (param === 'all') return new Set(RESPONSIBILITY_ORDER);
+  const selected = param
+    .split(',')
+    .filter((v): v is ResponsibilityKey => RESPONSIBILITY_ORDER.includes(v as ResponsibilityKey));
+  return new Set(selected);
+}
+
+function serializeScopesParam(selected: Set<ResponsibilityKey>): string | undefined {
+  if (selected.size === 1 && selected.has('template')) return undefined;
+  if (selected.size === RESPONSIBILITY_ORDER.length) return 'all';
+  return RESPONSIBILITY_ORDER.filter((scope) => selected.has(scope)).join(',') || 'none';
 }
 
 function statusPillClass(status: StatusKey): string {
@@ -105,14 +121,23 @@ function getStatusCount(
 export function BddFeatureScenarioOverview({
   features,
   initialStatesParam,
-}: Readonly<{ features: BddFeatureOverview[]; initialStatesParam?: string }>): JSX.Element {
+  initialScopesParam,
+}: Readonly<{
+  features: BddFeatureOverview[];
+  initialStatesParam?: string;
+  initialScopesParam?: string;
+}>): JSX.Element {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const urlStatesParam = searchParams.get('states') ?? undefined;
+  const urlScopesParam = searchParams.get('scopes') ?? undefined;
 
   const [selectedStatuses, setSelectedStatuses] = useState<Set<StatusKey>>(() =>
     parseStatesParam(initialStatesParam)
+  );
+  const [selectedScopes, setSelectedScopes] = useState<Set<ResponsibilityKey>>(() =>
+    parseScopesParam(initialScopesParam)
   );
 
   useEffect(() => {
@@ -121,25 +146,36 @@ export function BddFeatureScenarioOverview({
   }, [urlStatesParam]);
 
   useEffect(() => {
-    const desiredParam = serializeStatesParam(selectedStatuses);
-    const currentParam = urlStatesParam;
+    setSelectedScopes(parseScopesParam(urlScopesParam));
+  }, [urlScopesParam]);
 
-    if (desiredParam === undefined && currentParam === undefined) return;
-    if (desiredParam !== currentParam) {
-      const nextSearch = new URLSearchParams(searchParams.toString());
-      if (desiredParam === undefined) nextSearch.delete('states');
-      else nextSearch.set('states', desiredParam);
-
-      const qs = nextSearch.toString();
-      const href = (qs ? `${pathname}?${qs}` : pathname) as Route;
-      router.replace(href, { scroll: false });
-    }
-  }, [pathname, router, searchParams, selectedStatuses, urlStatesParam]);
+  useEffect(() => {
+    const desiredStates = serializeStatesParam(selectedStatuses);
+    const desiredScopes = serializeScopesParam(selectedScopes);
+    if (desiredStates === urlStatesParam && desiredScopes === urlScopesParam) return;
+    const nextSearch = new URLSearchParams(searchParams.toString());
+    if (desiredStates === undefined) nextSearch.delete('states');
+    else nextSearch.set('states', desiredStates);
+    if (desiredScopes === undefined) nextSearch.delete('scopes');
+    else nextSearch.set('scopes', desiredScopes);
+    const qs = nextSearch.toString();
+    router.replace((qs ? `${pathname}?${qs}` : pathname) as Route, { scroll: false });
+  }, [
+    pathname,
+    router,
+    searchParams,
+    selectedScopes,
+    selectedStatuses,
+    urlScopesParam,
+    urlStatesParam,
+  ]);
 
   const filtered = useMemo(() => {
     const out = features
       .map((f) => {
-        const scenarios = f.scenarios.filter((s) => selectedStatuses.has(s.status));
+        const scenarios = f.scenarios.filter(
+          (s) => selectedStatuses.has(s.status) && selectedScopes.has(s.responsibility)
+        );
         const counts = {
           total: scenarios.length,
           ready: scenarios.filter((s) => s.status === 'ready').length,
@@ -159,7 +195,7 @@ export function BddFeatureScenarioOverview({
 
     const scenarioCount = out.reduce((acc, f) => acc + f.scenarios.length, 0);
     return { features: out, scenarioCount };
-  }, [features, selectedStatuses]);
+  }, [features, selectedScopes, selectedStatuses]);
 
   function setAll(next: boolean): void {
     setSelectedStatuses(new Set(next ? STATUS_ORDER : []));
@@ -229,6 +265,41 @@ export function BddFeatureScenarioOverview({
         </div>
       </div>
 
+      <div className="mt-3 rounded-lg border bg-white p-4">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="text-sm font-medium">Filter by responsibility</div>
+          <button
+            type="button"
+            className="text-xs rounded-md border bg-white px-3 py-1.5 hover:bg-gray-50"
+            onClick={() => {
+              setSelectedScopes(new Set(['adopter']));
+              setSelectedStatuses(new Set(['wip']));
+            }}
+          >
+            Adopter backlog
+          </button>
+        </div>
+        <div className="mt-2 flex flex-wrap gap-4">
+          {RESPONSIBILITY_ORDER.map((scope) => (
+            <label key={scope} className="flex items-center gap-2 text-sm capitalize">
+              <input
+                type="checkbox"
+                checked={selectedScopes.has(scope)}
+                onChange={(event) => {
+                  setSelectedScopes((previous) => {
+                    const next = new Set(previous);
+                    if (event.target.checked) next.add(scope);
+                    else next.delete(scope);
+                    return next;
+                  });
+                }}
+              />
+              {scope}
+            </label>
+          ))}
+        </div>
+      </div>
+
       <div className="mt-4 space-y-3">
         {filtered.features.map((f) => {
           return (
@@ -281,6 +352,7 @@ export function BddFeatureScenarioOverview({
                       <tr>
                         <th className="text-left font-medium px-3 py-2">Scenario</th>
                         <th className="text-left font-medium px-3 py-2">Status</th>
+                        <th className="text-left font-medium px-3 py-2">Responsibility</th>
                         <th className="text-left font-medium px-3 py-2">Impl</th>
                         <th className="text-left font-medium px-3 py-2">Tags</th>
                       </tr>
@@ -299,6 +371,7 @@ export function BddFeatureScenarioOverview({
                                 {formatStatusLabel(s.status)}
                               </span>
                             </td>
+                            <td className="px-3 py-2 capitalize">{s.responsibility}</td>
                             <td className="px-3 py-2">
                               {s.implTags.length ? (
                                 <span className="font-mono text-xs">{s.implTags.join(' ')}</span>

--- a/apps/frontend/app/dashboard/bdd/page.tsx
+++ b/apps/frontend/app/dashboard/bdd/page.tsx
@@ -61,12 +61,16 @@ export default async function BddDashboardPage({
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
 
   let statesParam: string | undefined;
+  let scopesParam: string | undefined;
   const rawStates = resolvedSearchParams?.['states'];
   if (typeof rawStates === 'string') {
     statesParam = rawStates;
   } else if (Array.isArray(rawStates)) {
     statesParam = rawStates[0];
   }
+  const rawScopes = resolvedSearchParams?.['scopes'];
+  if (typeof rawScopes === 'string') scopesParam = rawScopes;
+  else if (Array.isArray(rawScopes)) scopesParam = rawScopes[0];
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -84,10 +88,11 @@ export default async function BddDashboardPage({
         </div>
 
         <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          <StatCard title="Total scenarios" value={`${snapshot.overall.total}`} />
+          <StatCard title="Template scenarios" value={`${snapshot.responsibility.template}`} />
+          <StatCard title="Adopter scenarios" value={`${snapshot.responsibility.adopter}`} />
           <StatCard title="Ready" value={`${snapshot.overall.ready}`} sub="Default CI gate" />
           <StatCard title="WIP" value={`${snapshot.overall.wip}`} />
-          <StatCard title="Manual" value={`${snapshot.overall.manual}`} />
+          <StatCard title="Total scenarios" value={`${snapshot.overall.total}`} />
         </div>
 
         <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -145,6 +150,18 @@ export default async function BddDashboardPage({
               </div>
             </div>
             <div className="rounded-lg border bg-white p-4">
+              <div className="font-medium">Missing responsibility tags</div>
+              <div className="mt-1 text-xs text-gray-500">
+                Count: {snapshot.issues.missingResponsibility.length} (expected 0)
+              </div>
+            </div>
+            <div className="rounded-lg border bg-white p-4">
+              <div className="font-medium">Conflicting responsibility tags</div>
+              <div className="mt-1 text-xs text-gray-500">
+                Count: {snapshot.issues.conflictingResponsibility.length} (expected 0)
+              </div>
+            </div>
+            <div className="rounded-lg border bg-white p-4">
               <div className="font-medium">Conflicting status tags</div>
               <div className="mt-1 text-xs text-gray-500">
                 Count: {snapshot.issues.conflictingStatus.length} (expected 0)
@@ -153,7 +170,11 @@ export default async function BddDashboardPage({
           </div>
         </div>
 
-        <BddFeatureScenarioOverview features={snapshot.features} initialStatesParam={statesParam} />
+        <BddFeatureScenarioOverview
+          features={snapshot.features}
+          initialStatesParam={statesParam}
+          initialScopesParam={scopesParam}
+        />
       </main>
     </div>
   );

--- a/apps/frontend/app/dashboard/bdd/types.ts
+++ b/apps/frontend/app/dashboard/bdd/types.ts
@@ -4,6 +4,8 @@ export type {
   BddFeatureOverview,
   BddScenarioOverview,
   Snapshot,
+  ResponsibilityCounts,
+  ResponsibilityKey,
   StatusCounts,
   StatusKey,
 } from '@/lib/contracts/bdd-types';

--- a/apps/frontend/cucumber.js
+++ b/apps/frontend/cucumber.js
@@ -21,7 +21,7 @@ const common = {
 module.exports = {
   default: {
     ...common,
-    tags: '@ready and not @skip',
+    tags: '@template and @ready and not @skip',
   },
   all: {
     ...common,
@@ -30,6 +30,10 @@ module.exports = {
   wip: {
     ...common,
     tags: '@wip and not @skip',
+  },
+  adopter: {
+    ...common,
+    tags: '@adopter and not @skip',
   },
   manual: {
     ...common,

--- a/apps/frontend/features/01-i18n.feature
+++ b/apps/frontend/features/01-i18n.feature
@@ -1,3 +1,4 @@
+@template
 Feature: Internationalization (i18n)
   As a user
   I want the UI to support multiple languages

--- a/apps/frontend/features/04-error-handling.feature
+++ b/apps/frontend/features/04-error-handling.feature
@@ -9,6 +9,7 @@ Feature: Error Handling and Recovery
     Given the application is running
 
   @ready @boundary @critical @impl_frontend_global_error_boundary
+  @template
   Scenario: Global error boundary catches errors
     Given I am on the application
     When a component throws an unexpected error
@@ -18,6 +19,7 @@ Feature: Error Handling and Recovery
     And I should have an option to go back to home
 
   @ready @404 @impl_frontend_not_found_page
+  @template
   Scenario: Handle 404 - Page not found
     When I navigate to a non-existent page "/this-does-not-exist"
     Then I should see a 404 error page
@@ -41,6 +43,7 @@ Feature: Error Handling and Recovery
     And after signing in, I should be redirected to the original page
 
   @ready @500 @impl_frontend_error_page
+  @template
   Scenario: Handle 500 - Server error
     Given the API returns a 500 error
     When I try to load a page
@@ -99,6 +102,7 @@ Feature: Error Handling and Recovery
     And I should be able to manually dismiss it
 
   @ready @recovery @impl_frontend_error_recovery
+  @template
   Scenario: Error recovery with action retry
     Given an API request failed
     When I see the error message
@@ -142,6 +146,7 @@ Feature: Error Handling and Recovery
     And my data should still be there
 
   @ready @javascript-error @impl_frontend_error_logging
+  @template
   Scenario: Catch and report JavaScript errors
     Given I am using the application
     When a JavaScript error occurs
@@ -191,6 +196,7 @@ Feature: Error Handling and Recovery
     And the error log should include browser information
 
   @ready @accessibility @impl_frontend_accessible_errors
+  @template
   Scenario: Error messages are accessible
     Given I am using a screen reader
     When an error occurs

--- a/apps/frontend/features/04-nextjs-frontend.feature
+++ b/apps/frontend/features/04-nextjs-frontend.feature
@@ -9,6 +9,7 @@ Feature: Next.js Frontend Application
     And the backend API is running on port 3001
 
   @ready @frontend @nextjs @app-router @impl_frontend_app_router
+  @template
   Scenario: Next.js App Router architecture
     Given Next.js App Router is configured
     When I inspect the route entries
@@ -17,6 +18,7 @@ Feature: Next.js Frontend Application
     And client components should be marked with "use client"
 
   @ready @frontend @auth @backend-only @impl_frontend_backend_only_auth
+  @template
   Scenario: Backend-only authentication setup
     Given ADR-011 backend-only auth is configured in the frontend
     When I inspect the frontend auth boundary
@@ -25,6 +27,7 @@ Feature: Next.js Frontend Application
     And server-rendered auth checks should call the backend current-user endpoint
 
   @ready @frontend @auth @login @backend-only @impl_frontend_backend_only_login
+  @template
   Scenario: User login with backend-only auth
     Given the sign-in client uses the auth hook
     When I inspect the sign-in flow
@@ -52,6 +55,7 @@ Feature: Next.js Frontend Application
     And I should be redirected to home page
 
   @ready @frontend @dashboard @auth @impl_frontend_dashboard_auth_gateway
+  @template
   Scenario: Protected dashboard access
     Given the dashboard page requires the current user
     When unauthenticated user accesses protected route
@@ -61,6 +65,7 @@ Feature: Next.js Frontend Application
     And user information should be displayed
 
   @ready @frontend @tanstack-query @setup @impl_frontend_query_provider
+  @template
   Scenario: TanStack Query configuration
     Given TanStack Query is set up
     When the application loads
@@ -96,6 +101,7 @@ Feature: Next.js Frontend Application
     And retry button should be available
 
   @ready @frontend @tailwind @impl_frontend_tailwind
+  @template
   Scenario: Tailwind CSS styling
     Given Tailwind CSS 4 is configured
     When I inspect components
@@ -104,6 +110,7 @@ Feature: Next.js Frontend Application
     And dark mode should be supported
 
   @ready @frontend @responsive @impl_frontend_responsive_layout
+  @template
   Scenario: Responsive layout
     When I view the site on mobile "<device>"
     Then layout should adapt to screen size
@@ -126,6 +133,7 @@ Feature: Next.js Frontend Application
     Then dark mode preference should persist
 
   @ready @frontend @seo @metadata @impl_frontend_metadata
+  @template
   Scenario: SEO metadata configuration
     Given SEO metadata is configured
     When I view page source
@@ -157,6 +165,7 @@ Feature: Next.js Frontend Application
     And FOUT/FOIT should be prevented
 
   @ready @frontend @route-protection @impl_frontend_route_auth
+  @template
   Scenario: Route-level authentication
     Given certain routes require authentication
     When unauthenticated user accesses protected route
@@ -187,6 +196,7 @@ Feature: Next.js Frontend Application
     Then validation should pass
 
   @ready @frontend @error-pages @impl_frontend_custom_error_pages
+  @template
   Scenario: Custom error pages
     When I navigate to non-existent route
     Then custom 404 page should be shown
@@ -195,6 +205,7 @@ Feature: Next.js Frontend Application
     Then custom 500 page should be shown
 
   @ready @frontend @loading-states @impl_frontend_loading_ui
+  @template
   Scenario: Loading UI with Suspense
     Given a page uses React Suspense
     When the page loads
@@ -211,6 +222,7 @@ Feature: Next.js Frontend Application
     And time to first byte should be minimal
 
   @ready @frontend @api-routes @impl_frontend_route_handlers
+  @template
   Scenario: Next.js API routes with Route Handlers
     When I inspect GET "/api/health"
     Then the API route should respond
@@ -218,6 +230,7 @@ Feature: Next.js Frontend Application
     And status code should be 200
 
   @ready @frontend @middleware @impl_frontend_middleware
+  @template
   Scenario: Next.js middleware for request handling
     Given middleware is configured
     When I make a request

--- a/apps/frontend/features/09-frontend-core.feature
+++ b/apps/frontend/features/09-frontend-core.feature
@@ -24,6 +24,7 @@ Feature: Frontend Core Features
     And the response should match the handler definition
 
   @ready @frontend @api-client @impl_frontend_typed_api_client
+  @template
   Scenario: Type-safe API client
     Given a type-safe API client is configured
     When I make an API request using the client
@@ -33,6 +34,7 @@ Feature: Frontend Core Features
 
   @frontend @api-client @error-handling @impl_frontend_error_handling
   @ready
+  @template
   Scenario: API client error handling
     Given the API client is configured
     When an API request fails with status "<status>"
@@ -49,6 +51,7 @@ Feature: Frontend Core Features
 
   @frontend @error-boundary @impl_frontend_error_handling
   @ready
+  @template
   Scenario: React error boundary
     Given an error boundary is configured
     When a component throws an error
@@ -57,6 +60,7 @@ Feature: Frontend Core Features
     And the error should be logged
 
   @frontend @websocket @ready @impl_frontend_websocket_hook
+  @template
   Scenario: WebSocket hook wiring
     Given the WebSocket hook is implemented
     Then it should use socket.io-client
@@ -64,6 +68,7 @@ Feature: Frontend Core Features
     And it should support reconnection state transitions
 
   @ready @frontend @error-boundary @recovery @impl_frontend_error_boundary_recovery
+  @template
   Scenario: Error boundary recovery
     Given an error boundary with retry functionality
     When a component errors and user clicks retry
@@ -93,6 +98,7 @@ Feature: Frontend Core Features
     Then the feature should be disabled
 
   @ready @frontend @loading-states @impl_frontend_loading_state
+  @template
   Scenario: Loading state management
     Given a component fetches data from API
     When the API request is in progress
@@ -121,6 +127,7 @@ Feature: Frontend Core Features
     And loading indicator should be shown during fetch
 
   @ready @frontend @caching @query @impl_frontend_query_caching
+  @template
   Scenario: TanStack Query caching
     Given TanStack Query is configured
     When I fetch data for a query
@@ -138,6 +145,7 @@ Feature: Frontend Core Features
     And UI should update with fresh data
 
   @ready @frontend @offline @impl_frontend_offline_detection
+  @template
   Scenario: Offline detection and handling
     Given offline detection is enabled
     When the user goes offline
@@ -149,6 +157,7 @@ Feature: Frontend Core Features
     And pending requests should be retried
 
   @ready @frontend @accessibility @aria @impl_frontend_semantic_accessibility
+  @template
   Scenario: ARIA labels and semantic HTML
     Given components use semantic HTML
     When I inspect a button component
@@ -166,6 +175,7 @@ Feature: Frontend Core Features
     Then focus should return to trigger element
 
   @ready @frontend @accessibility @keyboard @impl_frontend_keyboard_navigation
+  @template
   Scenario: Keyboard navigation
     Given interactive components exist
     When I navigate using Tab key
@@ -174,6 +184,7 @@ Feature: Frontend Core Features
     And Enter/Space should activate elements
 
   @ready @frontend @forms @validation @impl_frontend_form_validation
+  @template
   Scenario: Form validation
     Given a form with validation rules
     When I submit invalid data

--- a/apps/frontend/lib/contracts/bdd-types.ts
+++ b/apps/frontend/lib/contracts/bdd-types.ts
@@ -1,4 +1,5 @@
 export type StatusKey = 'ready' | 'wip' | 'manual' | 'skip' | 'other';
+export type ResponsibilityKey = 'template' | 'adopter' | 'other';
 
 export type StatusCounts = {
   total: number;
@@ -9,12 +10,20 @@ export type StatusCounts = {
   other: number;
 };
 
+export type ResponsibilityCounts = {
+  total: number;
+  template: number;
+  adopter: number;
+  other: number;
+};
+
 export type BddScenarioOverview = {
   appName: string;
   filePath: string;
   featureName: string;
   scenarioName: string;
   status: StatusKey;
+  responsibility: ResponsibilityKey;
   tags: string[];
   implTags: string[];
 };
@@ -33,9 +42,17 @@ export type Snapshot = {
   apps: Array<{ appName: string; counts: StatusCounts }>;
   features: BddFeatureOverview[];
   overall: StatusCounts;
+  responsibility: ResponsibilityCounts;
   issues: {
     missingStatus: Array<{ filePath: string; scenarioName: string; tags: string[] }>;
     conflictingStatus: Array<{
+      filePath: string;
+      scenarioName: string;
+      tags: string[];
+      primaryStatusTags: string[];
+    }>;
+    missingResponsibility: Array<{ filePath: string; scenarioName: string; tags: string[] }>;
+    conflictingResponsibility: Array<{
       filePath: string;
       scenarioName: string;
       tags: string[];

--- a/apps/frontend/src/server/bdd/types.ts
+++ b/apps/frontend/src/server/bdd/types.ts
@@ -8,6 +8,8 @@ export type {
   BddFeatureOverview,
   BddScenarioOverview,
   Snapshot,
+  ResponsibilityCounts,
+  ResponsibilityKey,
   StatusCounts,
   StatusKey,
 } from '@/lib/contracts/bdd-types';

--- a/docs/BDD.md
+++ b/docs/BDD.md
@@ -118,6 +118,8 @@ Notes:
 
 ## Implementer Coverage Reference
 
+> Planned governance migration: status and responsibility will become independent dimensions. Every scenario will retain one status tag and gain exactly one responsibility tag: `@template` or `@adopter`. The dashboard will gain separate scope filters and default to template-owned scenarios. Until that migration lands, existing `@wip @adopter` scenarios remain the adopter catalog.
+
 The Gherkin files are the comprehensive, version-controlled list of behaviors available to teams adopting this template:
 
 - `apps/backend/features/*.feature`

--- a/docs/BDD.md
+++ b/docs/BDD.md
@@ -118,7 +118,7 @@ Notes:
 
 ## Implementer Coverage Reference
 
-> Planned governance migration: status and responsibility will become independent dimensions. Every scenario will retain one status tag and gain exactly one responsibility tag: `@template` or `@adopter`. The dashboard will gain separate scope filters and default to template-owned scenarios. Until that migration lands, existing `@wip @adopter` scenarios remain the adopter catalog.
+Status and responsibility are independent dimensions. Every scenario has one effective status and exactly one effective responsibility: `@template` or `@adopter`. Feature tags provide defaults; scenario tags override them.
 
 The Gherkin files are the comprehensive, version-controlled list of behaviors available to teams adopting this template:
 
@@ -128,15 +128,17 @@ The Gherkin files are the comprehensive, version-controlled list of behaviors av
 Use the scenario tags to distinguish responsibility:
 
 - `@ready` describes base-template behavior that is already implemented and enforced.
-- `@wip @adopter` describes product-, provider-, operations-, or UX-specific behavior that an adopting team may implement.
+- `@template` describes behavior maintained by the base repository.
+- `@adopter` describes product-, provider-, operations-, or UX-specific behavior that an adopting team may implement.
 - `@manual` describes behavior that requires documented manual verification.
 
 The BDD Governance dashboard presents the same source data as an implementer-friendly catalog. With the backend and frontend running, sign in as an administrator and open:
 
-- <http://localhost:3000/dashboard/bdd> for every feature and scenario
-- <http://localhost:3000/dashboard/bdd?states=wip> for the implementation backlog
+- <http://localhost:3000/dashboard/bdd> for template-owned scenarios (the default)
+- <http://localhost:3000/dashboard/bdd?scopes=all> for every feature and scenario
+- <http://localhost:3000/dashboard/bdd?scopes=adopter&states=wip> for the adopter implementation backlog
 
-The dashboard shows each scenario's feature file, effective status, `@impl_*` traceability tag, and other tags. In the WIP view, use the displayed `@adopter` tag to identify intended adopter work; a WIP scenario without `@adopter` is ordinary unfinished repository work and should not automatically become an adopter requirement.
+The dashboard shows each scenario's feature file, effective status, responsibility, `@impl_*` traceability tag, and other tags. Its responsibility filter defaults to `template`; the **Adopter backlog** preset selects `@adopter @wip` scenarios.
 
 For a non-UI view:
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -102,28 +102,16 @@ node scripts/publish-packages.js
 
 ## CI/CD Workflows
 
-### GitHub Actions Automated Publishing
+### GitHub Actions Manual Publishing
 
-The repository includes a GitHub Actions workflow (`.github/workflows/publish.yml`) for automated package publishing.
+The repository includes a manually triggered GitHub Actions workflow (`.github/workflows/publish.yml`) for package publishing.
 
 #### Workflow Triggers
 
-1. **Manual Dispatch** (recommended for testing)
-   - Go to Actions → Publish Packages → Run workflow
-   - Options:
-     - Dry-run mode (default: enabled)
-     - Custom registry URL (default: GitHub Packages)
-     - Packages filter (default: all publishable packages)
-
-2. **Git Tags** (automatic publishing)
-   - Push a version tag: `git tag v1.0.0 && git push --tags`
-   - Workflow publishes all non-private packages
-   - Always runs in production mode (no dry-run)
-
-3. **GitHub Releases** (automatic publishing)
-   - Create a release in GitHub UI
-   - Workflow publishes packages and updates release notes
-   - Release notes automatically include published package list
+- Go to Actions → Publish Packages → Run workflow.
+- Dry-run mode is enabled by default.
+- You may select a custom registry and package filter.
+- Tags and GitHub releases do not trigger package publication.
 
 #### Workflow Jobs
 
@@ -138,10 +126,6 @@ The repository includes a GitHub Actions workflow (`.github/workflows/publish.ym
    - Runs `scripts/publish-packages.js` with appropriate environment
    - Uses `GITHUB_TOKEN` for authentication (automatic)
    - Creates publish summary in GitHub Actions UI
-
-3. **Release Notes Job** (only for releases)
-   - Updates release notes with published package list
-   - Formats as: `@apkasten906/package-name@version`
 
 #### Required Secrets
 
@@ -167,20 +151,6 @@ The repository includes a GitHub Actions workflow (`.github/workflows/publish.ym
    - Packages filter: (leave empty for all)
 5. Click "Run workflow"
 6. Monitor output in Actions log
-
-#### Example: Publish via Git Tag
-
-```bash
-# Ensure all changes are committed
-git status
-
-# Create and push a version tag
-git tag v1.0.0
-git push origin v1.0.0
-
-# Workflow automatically triggers and publishes
-# Check Actions tab for progress
-```
 
 #### Example: Publishing to Internal Registry
 
@@ -271,6 +241,18 @@ Select the affected workspace packages, choose the semantic version bump, and de
 When a release is ready to prepare, manually run `.github/workflows/version-packages.yml` from the GitHub Actions tab. It uses the changeset files accumulated on `master` to open or update a `chore(release): version packages` pull request. That pull request updates package versions and package-level changelogs independently.
 
 The workflow does not run on ordinary pushes. It versions private packages so the repository can prepare `@repo/types` and future packages such as `@repo/contracts` before they become publishable. It does not publish packages or create tags. Publishing remains an explicit operation through the existing Publish Packages workflow after a package is marked `"private": false` and reviewed.
+
+### Template Repository Releases
+
+Repository/template releases are independent of package versioning. The current project goal is distribution through cloning and GitHub's **Use this template** feature; no workspace package is planned for publication.
+
+After the planned BDD responsibility-taxonomy work is merged:
+
+1. Choose the template milestone version.
+2. Create the repository tag manually from the final merged `master` commit.
+3. Create the GitHub release from that tag.
+
+Do not run the Version Packages or Publish Packages workflows for this milestone. They are retained for a future decision to distribute workspace packages independently.
 
 ## Service Mesh Integration
 
@@ -419,7 +401,7 @@ turbo run build --filter=@apkasten906/types
 
 ## Future Enhancements
 
-- [x] **GitHub Actions workflow for automated publishing** - IMPLEMENTED (`.github/workflows/publish.yml`)
+- [x] **GitHub Actions workflow for manual publishing** - IMPLEMENTED (`.github/workflows/publish.yml`)
 - [x] **Changesets versioning** - Version Packages PR automation is implemented
 - [ ] Provenance attestation for published packages
 - [ ] NPM package signing
@@ -429,7 +411,7 @@ turbo run build --filter=@apkasten906/types
 ## Completed Features
 
 ✅ **Registry-agnostic publishing script** - `scripts/publish-packages.js` supports any npm-compatible registry
-✅ **GitHub Actions workflow** - Automated publishing via manual dispatch, tags, or releases
+✅ **GitHub Actions workflow** - Explicit package publishing through manual dispatch
 ✅ **Dry-run mode** - Test publishing without actually uploading packages
 ✅ **Package filtering** - Selectively publish specific packages
 ✅ **Service mesh support** - Route publishing through internal registries via environment variables

--- a/scripts/bdd-status.js
+++ b/scripts/bdd-status.js
@@ -15,6 +15,7 @@ const PRIMARY_STATUS_TAGS = /** @type {const} */ ([
   STATUS_TAGS.wip,
   STATUS_TAGS.manual,
 ]);
+const RESPONSIBILITY_TAGS = /** @type {const} */ (['@template', '@adopter']);
 
 /**
  * @param {string} line
@@ -73,14 +74,23 @@ function buildScenarioTags(featureTags, pendingTags) {
   // This allows gradual promotion within a feature that still defaults to @wip.
   const effectivePrimaryStatusTags =
     scenarioPrimaryStatusTags.length > 0 ? scenarioPrimaryStatusTags : featurePrimaryStatusTags;
+  const featureResponsibilityTags = RESPONSIBILITY_TAGS.filter((t) => featureTags.includes(t));
+  const scenarioResponsibilityTags = RESPONSIBILITY_TAGS.filter((t) => pendingTags.includes(t));
+  const effectiveResponsibilityTags =
+    scenarioResponsibilityTags.length > 0 ? scenarioResponsibilityTags : featureResponsibilityTags;
 
   const scenarioTags = Array.from(
     new Set([
       // Keep all non-status tags from both scopes.
-      ...featureTags.filter((t) => !PRIMARY_STATUS_TAGS.includes(t)),
-      ...pendingTags.filter((t) => !PRIMARY_STATUS_TAGS.includes(t)),
+      ...featureTags.filter(
+        (t) => !PRIMARY_STATUS_TAGS.includes(t) && !RESPONSIBILITY_TAGS.includes(t)
+      ),
+      ...pendingTags.filter(
+        (t) => !PRIMARY_STATUS_TAGS.includes(t) && !RESPONSIBILITY_TAGS.includes(t)
+      ),
       // Apply the effective status tags.
       ...effectivePrimaryStatusTags,
+      ...effectiveResponsibilityTags,
     ])
   );
 
@@ -89,6 +99,7 @@ function buildScenarioTags(featureTags, pendingTags) {
     featurePrimaryStatusTags,
     scenarioPrimaryStatusTags,
     effectivePrimaryStatusTags,
+    effectiveResponsibilityTags,
   };
 }
 
@@ -187,6 +198,7 @@ function parseFeatureFile(filePath, fileContent, missingStatus, conflictingStatu
         featurePrimaryStatusTags,
         scenarioPrimaryStatusTags,
         effectivePrimaryStatusTags,
+        effectiveResponsibilityTags,
       } = buildScenarioTags(featureTags, pendingTags);
       pendingTags = [];
 
@@ -200,6 +212,15 @@ function parseFeatureFile(filePath, fileContent, missingStatus, conflictingStatu
         missingStatus,
         conflictingStatus,
       });
+
+      if (effectiveResponsibilityTags.length !== 1) {
+        conflictingStatus.push({
+          filePath,
+          scenarioName,
+          tags: scenarioTags,
+          primaryStatusTags: effectiveResponsibilityTags,
+        });
+      }
 
       counts.total += 1;
       const status = classify(scenarioTags);


### PR DESCRIPTION
# Pull Request

## Summary

Separate BDD execution status from coverage responsibility so adopter guidance is no longer presented as unfinished template work.

- Add mutually exclusive `@template` and `@adopter` responsibility tags alongside the existing `@ready`, `@wip`, `@manual`, and `@skip` statuses.
- Classify all 387 scenarios:
  - 171 `@ready @template` scenarios maintained by the base template.
  - 216 `@wip @adopter` scenarios retained as implementation guidance for adopters.
- Enforce exactly one effective responsibility per scenario in the BDD governance CLI and backend snapshot.
- Make default Cucumber profiles select only `@template @ready` scenarios.
- Add adopter-specific Cucumber profiles.
- Add responsibility counts and filters to the BDD dashboard.
- Default the dashboard to template scope and provide an **Adopter backlog** preset.
- Update the frontend BDD contracts and backend governance tests.
- Update the README, BDD guide, changelog, progress tracker, and implementation plan.
- Make package publishing manual-only:
  - Repository tags and GitHub releases no longer publish packages.
  - The publishing workflow retains explicit manual dispatch with dry-run enabled by default.
  - Repository/template releases remain separate from package versioning and publication.

After this PR is merged, the repository can receive a manually created template milestone tag and GitHub release. The Version Packages and Publish Packages workflows are not needed for that milestone.

## Testing

- `pnpm -s bdd:status`
  - 387 scenarios classified.
  - 171 ready/template scenarios.
  - 216 WIP/adopter scenarios.
  - Zero missing or conflicting responsibility tags.
- `node scripts/bdd-impl-audit.js --fail-on-missing-ready-impl`
  - Zero ready scenarios missing `@impl_*` traceability.
- Backend and frontend TypeScript checks passed.
- Focused backend BDD governance and admin-route tests passed: 2 files, 4 tests.
- Backend and frontend default/adopter Cucumber profiles passed dry-run validation.
- Pre-push backend tests passed: 3 files and 8 tests.
- Prettier validation passed.
- Workflow lint passed.
- `git diff --check` passed.

## Checklist

- [ ] CI is green
- [x] No secrets added/printed

### If this PR touches `.github/workflows/` or `.github/dependabot.yml`

- [x] Workflow/job `permissions:` are least-privilege
- [x] Actions are pinned to commit SHAs (keep the `# vX` comment)
- [x] No `:latest` Docker images (prefer pinned versions)
- [x] `Workflow Lint` check passes
- [x] CI toolchain matches root `package.json` (`engines.node`, `packageManager`)